### PR TITLE
FOLIO-1253 generate-api-docs yarn

### DIFF
--- a/jenkins-slave-docker/Dockerfile
+++ b/jenkins-slave-docker/Dockerfile
@@ -128,7 +128,7 @@ RUN apt-get -q update && \
 RUN cd /usr/local && \
     git clone https://github.com/folio-org/folio-tools && \
     cd /usr/local/folio-tools/generate-api-docs && \
-    npm install && \
+    yarn install && \
     ln -s /usr/local/folio-tools/generate-api-docs/generate_api_docs.py \
     /usr/local/bin/generate_api_docs.py && \
     chmod +x /usr/local/folio-tools/generate-api-docs/generate_api_docs.py


### PR DESCRIPTION
Need to use yarn aliases for multiple versions of a dependency
raml2html to enable either RAML-0.8 or RAML-1.0