### PR TITLE
FOLIO-1027 ci lint raml cop 5

### DIFF
--- a/lint-raml/lint_raml_cop.py
+++ b/lint-raml/lint_raml_cop.py
@@ -53,8 +53,8 @@ def main():
                         help="Pathname to local configuration file. (Default: api.yml)")
     args = parser.parse_args()
 
-    print("Start lint-raml-cop", file=sys.stderr)
     loglevel = LOGLEVELS.get(args.loglevel.lower(), logging.NOTSET)
+    # Need stdout to enable Jenkins to redirect into an output file
     logging.basicConfig(stream=sys.stdout, format="%(levelname)s: %(name)s: %(message)s", level=loglevel)
     logger = logging.getLogger("lint-raml-cop")
     logging.getLogger("sh").setLevel(logging.ERROR)


### PR DESCRIPTION
The summary is that we need to direct python logging to stdout to enable Jenkins to redirect into an output file.