### PR TITLE
FOLIO-1399 lint-raml rmb20

### DIFF
--- a/lint-raml/README.md
+++ b/lint-raml/README.md
@@ -24,16 +24,20 @@ There is some assistance at [dev.folio.org/guides/raml-cop](https://dev.folio.or
 
 ## lint_raml_cop.py
 
-Python script to discover RAML files in a project and run 'raml-cop'.
+Python script to discover RAML files in a project, assess them, and run 'raml-cop'.
 
 Validates the RAML, ensures the $ref links in JSON Schema, and processes the examples.
 
-Does not assess the schema name declaration key names in the RAML file.
+Assesses the RAML files to detect various inconsistencies, before running raml-cop.
+Detecting these early helps with understanding the messages from the raml parser.
+
+The schema name declaration key names in the RAML file have particular needs when being used with RMB.
+This script attempts to assess those, for both pre and post RMB v20.
 
 ### Prerequisites
 
 - python3+
-- npm
+- yarn
 - [raml-cop](https://github.com/thebinarypenguin/raml-cop) (see below)
 - Some extra Python modules (see requirements.txt).
 
@@ -43,7 +47,7 @@ Occasionally update raml-cop:
 
 ```shell
 cd folio-tools/lint-raml
-npm install
+yarn install
 ```
 
 Install the extra Python modules:
@@ -69,6 +73,8 @@ Shell script to discover RAML files in a project and run 'raml-cop'.
 Validates the RAML, ensures the $ref links in JSON Schema, and processes the examples.
 
 Does not assess the schema name declaration key names in the RAML file.
+
+*Note* that this does not work with RMB >= v20
 
 ### Prerequisites
 

--- a/lint-raml/lint_raml_cop.py
+++ b/lint-raml/lint_raml_cop.py
@@ -14,7 +14,9 @@ import glob
 import logging
 import os
 import re
+import shutil
 import sys
+import tempfile
 
 import requests
 import sh
@@ -62,26 +64,26 @@ def main():
 
     # Process and validate the input parameters
     if args.input.startswith("~"):
-        input_dir = os.path.expanduser(args.input)
+        git_input_dir = os.path.expanduser(args.input)
     else:
-        input_dir = args.input
-    if not os.path.exists(input_dir):
-        msg = "Specified input directory of git clone (-i) not found: {0}".format(input_dir)
+        git_input_dir = args.input
+    if not os.path.exists(git_input_dir):
+        msg = "Specified input directory of git clone (-i) not found: {0}".format(git_input_dir)
         logger.critical(msg)
         return 2
 
     # Get the repository name
     try:
-        repo_url = sh.git.config("--get", "remote.origin.url", _cwd=input_dir).stdout.decode().strip()
+        repo_url = sh.git.config("--get", "remote.origin.url", _cwd=git_input_dir).stdout.decode().strip()
     except sh.ErrorReturnCode as err:
         logger.critical("Trouble doing 'git config': %s", err.stderr.decode())
-        logger.critical("Could not determine remote.origin.url of git clone in specified input directory: %s", input_dir)
+        logger.critical("Could not determine remote.origin.url of git clone in specified input directory: %s", git_input_dir)
         return 2
     else:
         repo_name = os.path.splitext(os.path.basename(repo_url))[0]
 
     if args.file:
-        specific_raml_file_pn = os.path.join(input_dir, args.file)
+        specific_raml_file_pn = os.path.join(git_input_dir, args.file)
         if not os.path.exists(specific_raml_file_pn):
             logger.critical("Specific RAML file '%s' does not exist in '%s'", specific_raml_file_pn, repo_name)
             logger.critical("Needs to be pathname relative to top-level, e.g. ramls/item-storage.raml")
@@ -110,87 +112,99 @@ def main():
         logger.critical("See FOLIO-903. Add an entry to api.yml")
         return 2
 
-    version_re = re.compile(r"^#%RAML ([0-9.]+)")
-
     # Process each configured set of RAML files
+    version_re = re.compile(r"^#%RAML ([0-9.]+)")
     exit_code = 0
-    for docset in config[repo_name]:
-        logger.info("Investigating %s", os.path.join(repo_name, docset["directory"]))
-        ramls_dir = os.path.join(input_dir, docset["directory"])
-        if not os.path.exists(ramls_dir):
-            logger.critical("The 'ramls' directory not found: %s", ramls_dir)
+    with tempfile.TemporaryDirectory() as temp_dir:
+        # Copy everything to the temp directory
+        # because we might need to adjust $ref in schema files
+        input_dir = os.path.join(temp_dir, repo_name)
+        try:
+            shutil.copytree(git_input_dir, input_dir)
+        except:
+            logger.critical("Trouble copying to temporary directory: %s", input_dir)
             return 2
-        if docset["ramlutil"] is not None:
-            ramlutil_dir = os.path.join(input_dir, docset["ramlutil"])
-            if not os.path.exists(ramlutil_dir):
-                logger.warning("The specified 'raml-util' directory not found: %s", os.path.join(repo_name, docset["ramlutil"]))
-        # Ensure configuration and find any RAML files not configured
-        configured_raml_files = []
-        for raml_name in docset["files"]:
-            raml_fn = "{0}.raml".format(raml_name)
-            configured_raml_files.append(raml_fn)
-        found_raml_files = []
-        raml_files = []
-        if docset["label"] == "shared":
-            # If this is the top-level of the shared space, then do not descend
-            pattern = os.path.join(ramls_dir, "*.raml")
-            for raml_fn in glob.glob(pattern):
-                raml_pn = os.path.relpath(raml_fn, ramls_dir)
-                found_raml_files.append(raml_pn)
-        else:
-            exclude_list = ["raml-util", "rtypes", "traits", "node_modules"]
-            try:
-                exclude_list.extend(docset["excludes"])
-            except KeyError:
-                pass
-            excludes = set(exclude_list)
-            for root, dirs, files in os.walk(ramls_dir, topdown=True):
-                dirs[:] = [d for d in dirs if d not in excludes]
-                for raml_fn in fnmatch.filter(files, "*.raml"):
-                    if raml_fn in excludes:
-                        continue
-                    raml_pn = os.path.relpath(os.path.join(root, raml_fn), ramls_dir)
+        for docset in config[repo_name]:
+            logger.info("Investigating %s", os.path.join(repo_name, docset["directory"]))
+            ramls_dir = os.path.join(input_dir, docset["directory"])
+            if not os.path.exists(ramls_dir):
+                logger.critical("The specified 'ramls' directory not found: %s", os.path.join(repo_name, docset["directory"]))
+                return 2
+            if docset["ramlutil"] is not None:
+                ramlutil_dir = os.path.join(input_dir, docset["ramlutil"])
+                if not os.path.exists(ramlutil_dir):
+                    logger.warning("The specified 'raml-util' directory not found: %s", os.path.join(repo_name, docset["ramlutil"]))
+            # Ensure configuration and find any RAML files not configured
+            configured_raml_files = []
+            for raml_name in docset["files"]:
+                raml_fn = "{0}.raml".format(raml_name)
+                configured_raml_files.append(raml_fn)
+            found_raml_files = []
+            raml_files = []
+            if docset["label"] == "shared":
+                # If this is the top-level of the shared space, then do not descend
+                pattern = os.path.join(ramls_dir, "*.raml")
+                for raml_fn in glob.glob(pattern):
+                    raml_pn = os.path.relpath(raml_fn, ramls_dir)
                     found_raml_files.append(raml_pn)
-        for raml_fn in configured_raml_files:
-            if raml_fn not in found_raml_files:
-                logger.warning("Configured file not found: %s", raml_fn)
             else:
-                raml_files.append(raml_fn)
-        for raml_fn in found_raml_files:
-            if raml_fn not in configured_raml_files:
-                raml_files.append(raml_fn)
-                logger.warning("Missing from configuration: %s", raml_fn)
-        logger.debug("configured_raml_files: %s", configured_raml_files)
-        logger.debug("found_raml_files: %s", found_raml_files)
-        logger.debug("raml_files: %s", raml_files)
-        for raml_fn in raml_files:
-            if args.file:
-                if os.path.join(docset["directory"], raml_fn) != args.file:
-                    logger.info("Skipping RAML file: %s", raml_fn)
+                exclude_list = ["raml-util", "rtypes", "traits", "node_modules"]
+                try:
+                    exclude_list.extend(docset["excludes"])
+                except KeyError:
+                    pass
+                excludes = set(exclude_list)
+                for root, dirs, files in os.walk(ramls_dir, topdown=True):
+                    dirs[:] = [d for d in dirs if d not in excludes]
+                    for raml_fn in fnmatch.filter(files, "*.raml"):
+                        if raml_fn in excludes:
+                            continue
+                        raml_pn = os.path.relpath(os.path.join(root, raml_fn), ramls_dir)
+                        found_raml_files.append(raml_pn)
+            for raml_fn in configured_raml_files:
+                if raml_fn not in found_raml_files:
+                    logger.warning("Configured file not found: %s", raml_fn)
+                else:
+                    raml_files.append(raml_fn)
+            for raml_fn in found_raml_files:
+                if raml_fn not in configured_raml_files:
+                    raml_files.append(raml_fn)
+                    logger.warning("Missing from configuration: %s", raml_fn)
+            logger.debug("configured_raml_files: %s", configured_raml_files)
+            logger.debug("found_raml_files: %s", found_raml_files)
+            logger.debug("raml_files: %s", raml_files)
+            for raml_fn in raml_files:
+                if args.file:
+                    if os.path.join(docset["directory"], raml_fn) != args.file:
+                        logger.info("Skipping RAML file: %s", raml_fn)
+                        continue
+                input_pn = os.path.join(ramls_dir, raml_fn)
+                if not os.path.exists(input_pn):
+                    logger.warning("Missing configured input file '%s'", os.path.join(repo_name, raml_fn))
+                    logger.warning("Configuration needs to be updated (FOLIO-903).")
                     continue
-            input_pn = os.path.join(ramls_dir, raml_fn)
-            if not os.path.exists(input_pn):
-                logger.warning("Missing configured input file '%s'", os.path.join(repo_name, raml_fn))
-                logger.warning("Configuration needs to be updated (FOLIO-903).")
-                continue
-            logger.info("Processing RAML file: %s", raml_fn)
-            # Determine raml version
-            version_value = None
-            with open(input_pn, "r") as input_fh:
-                for num, line in enumerate(input_fh):
-                    match = re.search(version_re, line)
-                    if match:
-                        version_value = match.group(1)
-                        logger.info("Input file is RAML version: %s", version_value)
-                        break
-            # Now process this file
-            cmd_label = "raml-cop"
-            cmd = sh.Command(os.path.join(sys.path[0], "node_modules", ".bin", cmd_label))
-            try:
-                cmd(input_pn, no_color=True)
-            except sh.ErrorReturnCode_1 as err:
-                logger.error("%s has issues with %s:\n%s", raml_fn, cmd_label, err.stdout.decode())
-                exit_code = 1
+                logger.info("Processing RAML file: %s", raml_fn)
+                # Determine raml version
+                version_value = None
+                with open(input_pn, "r") as input_fh:
+                    for num, line in enumerate(input_fh):
+                        match = re.search(version_re, line)
+                        if match:
+                            version_value = match.group(1)
+                            logger.info("Input file is RAML version: %s", version_value)
+                            break
+                if not version_value:
+                    logger.error("Could not determine RAML version.")
+                    exit_code = 1
+                    continue
+                # Now process this file
+                cmd_label = "raml-cop"
+                cmd = sh.Command(os.path.join(sys.path[0], "node_modules", ".bin", cmd_label))
+                try:
+                    cmd(input_pn, no_color=True)
+                except sh.ErrorReturnCode_1 as err:
+                    logger.error("%s has issues with %s:\n%s", raml_fn, cmd_label, err.stdout.decode())
+                    exit_code = 1
     if exit_code == 1:
         logger.info("There were processing issues.")
     elif exit_code == 2:

--- a/lint-raml/lint_raml_cop.py
+++ b/lint-raml/lint_raml_cop.py
@@ -360,7 +360,7 @@ def gather_declarations(raml_input_pn, raml_input_fn, raml_version, is_rmb, inpu
         try:
             raml_content = yaml.load(input_fh)
         except yaml.scanner.ScannerError:
-            logger.critical("Trouble scanning RAML file '%s'", os.path.relpath(raml_input_pn, input_dir))
+            logger.critical("Trouble scanning RAML file '%s'", raml_input_fn)
             issues = True
             return (schemas, issues)
         # Handling of content is different for 0.8 and 1.0 raml.
@@ -368,7 +368,7 @@ def gather_declarations(raml_input_pn, raml_input_fn, raml_version, is_rmb, inpu
             try:
                 raml_content["schemas"]
             except KeyError:
-                logger.debug("No schemas were declared in '%s'", os.path.relpath(raml_input_pn, input_dir))
+                logger.debug("No schemas were declared in '%s'", raml_input_fn)
             else:
                 for decl in raml_content["schemas"]:
                     for key, schema_fn in decl.items():
@@ -381,7 +381,7 @@ def gather_declarations(raml_input_pn, raml_input_fn, raml_version, is_rmb, inpu
             try:
                 raml_content["traits"]
             except KeyError:
-                logger.debug("No traits were declared in '%s'", os.path.relpath(raml_input_pn, input_dir))
+                logger.debug("No traits were declared in '%s'", raml_input_fn)
             else:
                 for decl in raml_content["traits"]:
                     for key, trait_fn in decl.items():
@@ -395,7 +395,7 @@ def gather_declarations(raml_input_pn, raml_input_fn, raml_version, is_rmb, inpu
             try:
                 raml_content["types"]
             except KeyError:
-                logger.debug("No types were declared in '%s'", os.path.relpath(raml_input_pn, input_dir))
+                logger.debug("No types were declared in '%s'", raml_input_fn)
             else:
                 for decl in raml_content["types"]:
                     type_fn = raml_content["types"][decl]
@@ -407,11 +407,12 @@ def gather_declarations(raml_input_pn, raml_input_fn, raml_version, is_rmb, inpu
                             issues = True
                         if is_rmb and os.sep in decl:
                             logger.error("The key name '%s' must not be a path. Declared in the RAML types section.", decl)
+                            issues = True
                         schemas[decl] = type_fn
             try:
                 raml_content["traits"]
             except KeyError:
-                logger.debug("No traits were declared in '%s'", os.path.relpath(raml_input_pn, input_dir))
+                logger.debug("No traits were declared in '%s'", raml_input_fn)
             else:
                 for decl in raml_content["traits"]:
                     trait_fn = raml_content["traits"][decl]
@@ -429,7 +430,7 @@ def gather_declarations(raml_input_pn, raml_input_fn, raml_version, is_rmb, inpu
                     try:
                         schemas[schema_key]
                     except KeyError:
-                        logger.error("Missing declaration in '%s' for schema $ref '%s' defined in 'validation.raml'", os.path.relpath(raml_input_pn, input_dir), schema_key)
+                        logger.error("Missing declaration in '%s' for schema $ref '%s' defined in 'validation.raml'", raml_input_fn, schema_key)
                         issues = True
         return (schemas, issues)
 

--- a/lint-raml/lint_raml_cop.py
+++ b/lint-raml/lint_raml_cop.py
@@ -323,11 +323,13 @@ def main():
                 try:
                     cmd(input_pn, no_color=True)
                 except sh.ErrorReturnCode_1 as err:
-                    logger.error("%s has issues with %s:\n%s", raml_fn, cmd_name, err.stdout.decode())
+                    # Remove the temp_dir path from its messages
+                    error_text = re.sub("\[.*?{0}/".format(repo_name), "[", err.stdout.decode())
+                    logger.error("%s has issues with %s:\n%s", raml_fn, cmd_name, error_text)
                     exit_code = 1
                 else:
                     logger.debug("%s did not detect any issues with %s", cmd_name, raml_fn)
-                # Copy the perhaps-modified schemas and raml, if specified, for later investigation.
+                # If specified, copy the perhaps-modified schemas and raml for later investigation.
                 top_raml_dir = os.path.dirname(docset["directory"])
                 if args.output_dir != "":
                     temp_output_dir = os.path.join(output_dir, repo_name, top_raml_dir, raml_fn[:-5])

--- a/lint-raml/lint_raml_cop.py
+++ b/lint-raml/lint_raml_cop.py
@@ -333,6 +333,8 @@ def main():
                         shutil.copytree(input_dir, temp_output_dir)
                     except:
                         logger.warning("Trouble copying to temporary directory: %s", temp_output_dir)
+                # Restore git, ready for next processing run
+                restore_checkout(input_dir)
     if exit_code == 1:
         logger.info("There were processing issues.")
     elif exit_code == 2:
@@ -345,6 +347,14 @@ def main():
 def construct_raml_include(loader, node):
     "Add a special construct for YAML loader"
     return loader.construct_yaml_str(node)
+
+def restore_checkout(input_dir):
+    """Discard changes, so processing of each RAML file operates on a fresh working copy.
+    """
+    try:
+        sh.git.checkout("--", ".", _cwd=input_dir)
+    except:
+        print("Trouble with sh.git.checkout restoring %s", input_dir)
 
 def gather_declarations(raml_input_pn, raml_input_fn, raml_version, is_rmb, input_dir, docset_dir):
     """

--- a/lint-raml/lint_raml_cop.py
+++ b/lint-raml/lint_raml_cop.py
@@ -436,10 +436,14 @@ def gather_declarations(raml_input_pn, raml_input_fn, raml_version, is_rmb, inpu
                             issues = True
                         traits[decl] = trait_fn
         # Some traits declare additional schemas. Ensure that the raml declares them.
+        if raml_version == "0.8":
+            trait_schemas = ["errors", "error.schema", "parameters.schema"]
+        else:
+            trait_schemas = ["errors", "error", "parameters"]
         for trait in traits:
             trait_fn = traits[trait]
             if "validation.raml" in trait_fn:
-                for schema_key in ["errors", "error.schema", "parameters.schema"]:
+                for schema_key in trait_schemas:
                     try:
                         schemas[schema_key]
                     except KeyError:

--- a/lint-raml/lint_raml_cop.py
+++ b/lint-raml/lint_raml_cop.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 
-"""Assess a set of RAML and schema files using raml-cop.
+"""
+Assess a set of RAML and schema files, detect various inconsistencies, then run raml-cop.
+Detecting these early helps with understanding the messages from the raml parser.
 
    Returns:
        0: Success.
@@ -315,6 +317,7 @@ def main():
                                             else:
                                                 logger.error("The schema reference '%s' defined in '%s' is not declared in RAML file.", ref_value, schemas[schema])
                             output_fh.write(line)
+                # Sool raml-cop onto it.
                 cmd_name = "raml-cop"
                 cmd = sh.Command(os.path.join(sys.path[0], "node_modules", ".bin", cmd_name))
                 try:
@@ -332,7 +335,7 @@ def main():
                         logger.debug("Copying to %s", temp_output_dir)
                         shutil.copytree(input_dir, temp_output_dir)
                     except:
-                        logger.warning("Trouble copying to temporary directory: %s", temp_output_dir)
+                        logger.warning("Trouble copying to temporary directory (existing content?): %s", temp_output_dir)
                 # Restore git, ready for next processing run
                 restore_checkout(input_dir)
     if exit_code == 1:

--- a/lint-raml/lint_raml_cop.py
+++ b/lint-raml/lint_raml_cop.py
@@ -168,29 +168,29 @@ def main():
                 if os.path.join(docset["directory"], raml_fn) != args.file:
                     logger.info("Skipping RAML file: %s", raml_fn)
                     continue
-            logger.info("Processing RAML file: %s", raml_fn)
             input_pn = os.path.join(ramls_dir, raml_fn)
             if not os.path.exists(input_pn):
-                logger.warning("Missing input file '%s'", os.path.join(repo_name, raml_fn))
+                logger.warning("Missing configured input file '%s'", os.path.join(repo_name, raml_fn))
                 logger.warning("Configuration needs to be updated (FOLIO-903).")
-            else:
-                # Determine raml version
-                version_value = None
-                with open(input_pn, "r") as input_fh:
-                    for num, line in enumerate(input_fh):
-                        match = re.search(version_re, line)
-                        if match:
-                            version_value = match.group(1)
-                            logger.info("Input file is RAML version: %s", version_value)
-                            break
-                # Now process this file
-                cmd_label = "raml-cop"
-                cmd = sh.Command(os.path.join(sys.path[0], "node_modules", ".bin", cmd_label))
-                try:
-                    cmd(input_pn, no_color=True)
-                except sh.ErrorReturnCode_1 as err:
-                    logger.error("%s has issues with %s:\n%s", raml_fn, cmd_label, err.stdout.decode())
-                    exit_code = 1
+                continue
+            logger.info("Processing RAML file: %s", raml_fn)
+            # Determine raml version
+            version_value = None
+            with open(input_pn, "r") as input_fh:
+                for num, line in enumerate(input_fh):
+                    match = re.search(version_re, line)
+                    if match:
+                        version_value = match.group(1)
+                        logger.info("Input file is RAML version: %s", version_value)
+                        break
+            # Now process this file
+            cmd_label = "raml-cop"
+            cmd = sh.Command(os.path.join(sys.path[0], "node_modules", ".bin", cmd_label))
+            try:
+                cmd(input_pn, no_color=True)
+            except sh.ErrorReturnCode_1 as err:
+                logger.error("%s has issues with %s:\n%s", raml_fn, cmd_label, err.stdout.decode())
+                exit_code = 1
     if exit_code == 1:
         logger.info("There were processing issues.")
     elif exit_code == 2:


### PR DESCRIPTION
Detect when using RMBv20 and its RAML 1.0
Both pre and post RMB v20 have various peculiarities. Using raml-cop alone is not sufficient.

Assess the RAML and schema files, detect various inconsistencies, then run raml-cop.
Detecting these early helps with understanding the messages from the raml parser.

This version copies sources to a temporary directory, because with today's RMBv20 we need to replace non-standard schema $ref key names with declared pathnames. The RMB-203 might fix that later.