### PR TITLE
 RMB-227 Use raml-1-parser 1.1.45

### DIFF
--- a/lint-raml/package.json
+++ b/lint-raml/package.json
@@ -2,5 +2,8 @@
   "license": "Apache-2.0",
   "dependencies": {
     "raml-cop": "^5.0.0"
+  },
+  "resolutions": {
+    "raml-1-parser": "1.1.45"
   }
 }


### PR DESCRIPTION
The new 1.1.46 has trouble with our raml-1.0 rtypes
Go back to 1.1.45 until we can investigate.
Use yarn selective-version-resolutions