### PR TITLE
Add boto3 to Docker image for jenkins-slave-docker.

### DIFF
--- a/jenkins-slave-docker/Dockerfile
+++ b/jenkins-slave-docker/Dockerfile
@@ -106,6 +106,7 @@ RUN apt-get -q update && \
     -o Dpkg::Options::="--force-confnew"  --no-install-recommends \
     ansible python-jmespath && \
     pip install boto
+    pip install boto3
    
 
 # ruby/rvm


### PR DESCRIPTION
`ec2_facts` Ansible module has been deprecated, and functionality is now in `ec2_instance_facts`. This module requires boto 3. Towards FOLIO-1558.