### PR TITLE
FOLIO-589 generate-api-docs Use folio-org fork raml2html-plain-theme

### DIFF
--- a/generate-api-docs/package.json
+++ b/generate-api-docs/package.json
@@ -2,6 +2,6 @@
   "dependencies": {
     "raml2html": "^7.1.0",
     "raml2html3": "npm:raml2html@3.0.1",
-    "raml2html-plain-theme": "^0.1.5"
+    "raml2html-plain-theme": "folio-org/raml2html-plain-theme#folio-589"
   }
 }


### PR DESCRIPTION
Display all resource-body divs