### PR TITLE
FOLIO-1722: Updates: Alpine 3.10, openjdk-jre-base 8.222, agent-bond 1.2.0.

### DIFF
--- a/folio-java-docker/openjdk8/Dockerfile.openjdk8-jre-alpine
+++ b/folio-java-docker/openjdk8/Dockerfile.openjdk8-jre-alpine
@@ -1,36 +1,7 @@
-FROM alpine:3.5
+FROM fabric8/java-alpine-openjdk8-jre:latest
 
-USER root
-
-RUN mkdir -p /usr/verticles
-
-# JAVA_APP_DIR is used by run-java.sh for finding the binaries
 ENV JAVA_APP_DIR /usr/verticles
-ENV AGENT_BOND_VERSION 1.0.2
-
-RUN apk add --update \
-    curl \
-    bash \
-    openjdk8 \
- && rm /var/cache/apk/* \
- && echo "securerandom.source=file:/dev/urandom" >> /usr/lib/jvm/default-jvm/jre/lib/security/java.security
-
-# Agent bond including Jolokia and jmx_exporter
-ADD agent-bond-opts /opt/run-java-options
-RUN mkdir -p /opt/agent-bond \
- && curl http://central.maven.org/maven2/io/fabric8/agent-bond-agent/${AGENT_BOND_VERSION}/agent-bond-agent-${AGENT_BOND_VERSION}.jar \
-          -o /opt/agent-bond/agent-bond.jar \
- && chmod 444 /opt/agent-bond/agent-bond.jar \
- && chmod 755 /opt/run-java-options
-ADD jmx_exporter_config.yml /opt/agent-bond/
-EXPOSE 8778 9779
-
-# Add run script as JAVA_APP_DIR/run-java.sh and make it executable
-COPY run-java.sh debug-options container-limits java-default-options ${JAVA_APP_DIR}/
-RUN chmod 755 ${JAVA_APP_DIR}/run-java.sh \
-    ${JAVA_APP_DIR}/java-default-options \
-    ${JAVA_APP_DIR}/container-limits \
-    ${JAVA_APP_DIR}/debug-options
+RUN mv /deployments $JAVA_APP_DIR
 
 # Create user/group 'folio'
 RUN addgroup folio && \


### PR DESCRIPTION
The Alpine base FOLIO Docker image uses Alpine 3.5: https://github.com/folio-org/folio-tools/blob/76aa61f/folio-java-docker/openjdk8/Dockerfile.openjdk8-jre-alpine

Alpine 3.5 is out of support since 2018-11-01, no security updates:
https://wiki.alpinelinux.org/wiki/Alpine_Linux:Releases

Alpine 3.5 uses linux-vanilla 4.4.59-r1 that has more than 150 known security vulnerabilities: https://www.cvedetails.com/version/221677/Linux-Linux-Kernel-4.4.59.html

Alpine 3.5 uses openjdk8 8.191 that has more than 25 security vulnerabilities: https://pkgs.alpinelinux.org/packages?name=openjdk8&branch=v3.5 https://openjdk.java.net/groups/vulnerability/advisories/2019-10-15 https://openjdk.java.net/groups/vulnerability/advisories/2019-07-16 https://openjdk.java.net/groups/vulnerability/advisories/2019-04-16

Alpine 3.5 uses curl 7.61.1 that has 10 known security vulnerabilities: https://curl.haxx.se/docs/vuln-7.61.1.html

Alpine 3.5 uses busybox 1.25.1. that has 2 known security vulnerabilities: https://www.cvedetails.com/version/257068/Busybox-Busybox-1.25.1.html

Using the fabric8 image as a base will automatically update Alpine, openjdk and agent-bond.