### PR TITLE
FOLIO-1497 Improve lint-raml

### DIFF
--- a/lint-raml/README.md
+++ b/lint-raml/README.md
@@ -1,6 +1,6 @@
 # lint-raml -- Various processing tools to assist RAML and schema maintenance
 
-Copyright (C) 2016-2018 The Open Library Foundation
+Copyright (C) 2016-2019 The Open Library Foundation
 
 This software is distributed under the terms of the Apache License,
 Version 2.0. See the file "[LICENSE](LICENSE)" for more information.

--- a/lint-raml/lint_raml_cop.py
+++ b/lint-raml/lint_raml_cop.py
@@ -396,8 +396,8 @@ def gather_declarations(raml_input_pn, raml_input_fn, raml_version, is_rmb, inpu
     with open(raml_input_pn) as input_fh:
         try:
             raml_content = yaml.load(input_fh)
-        except yaml.scanner.ScannerError:
-            logger.critical("Trouble scanning RAML file '%s'", raml_input_fn)
+        except yaml.YAMLError as err:
+            logger.critical("Trouble parsing as YAML file '%s': %s", raml_input_fn, err)
             issues = True
             return (schemas, issues)
         # Handling of content is different for 0.8 and 1.0 raml.

--- a/lint-raml/lint_raml_cop.py
+++ b/lint-raml/lint_raml_cop.py
@@ -65,7 +65,9 @@ def main():
     loglevel = LOGLEVELS.get(args.loglevel.lower(), logging.NOTSET)
     # Need stdout to enable Jenkins to redirect into an output file
     logging.basicConfig(stream=sys.stdout, format="%(levelname)s: %(name)s: %(message)s", level=loglevel)
-    logger = logging.getLogger("lint-raml-cop")
+    logger1 = logging.getLogger("lint-raml")
+    logger2 = logging.getLogger("lint-raml-cop")
+    logger3 = logging.getLogger("lint-raml-schema")
     logging.getLogger("sh").setLevel(logging.ERROR)
     logging.getLogger("requests").setLevel(logging.ERROR)
 
@@ -75,27 +77,27 @@ def main():
     else:
         git_input_dir = args.input
     if not os.path.exists(git_input_dir):
-        logger.critical("Specified input directory of git clone (-i) not found: %s", git_input_dir)
+        logger1.critical("Specified input directory of git clone (-i) not found: %s", git_input_dir)
         return 2
 
     # Ensure that commands are available
     if sh.which("jq"):
         has_jq = True
     else:
-        logger.warning("'jq' is not available. So will not do extra JSON assessment.")
+        logger1.warning("'jq' is not available. So will not do extra JSON assessment.")
         has_jq = False
     bin_raml_cop = os.path.join(sys.path[0], "node_modules", ".bin", "raml-cop")
     if not os.path.exists(bin_raml_cop):
-        logger.critical("'raml-cop' is not available.")
-        logger.critical("Do 'yarn install' in folio-tools/lint-raml directory.")
+        logger1.critical("'raml-cop' is not available.")
+        logger1.critical("Do 'yarn install' in folio-tools/lint-raml directory.")
         return 2
 
     # Get the repository name
     try:
         repo_url = sh.git.config("--get", "remote.origin.url", _cwd=git_input_dir).stdout.decode().strip()
     except sh.ErrorReturnCode as err:
-        logger.critical("Trouble doing 'git config': %s", err.stderr.decode())
-        logger.critical("Could not determine remote.origin.url of git clone in specified input directory: %s", git_input_dir)
+        logger1.critical("Trouble doing 'git config': %s", err.stderr.decode())
+        logger1.critical("Could not determine remote.origin.url of git clone in specified input directory: %s", git_input_dir)
         return 2
     else:
         repo_name = os.path.splitext(os.path.basename(repo_url))[0]
@@ -103,8 +105,8 @@ def main():
     if args.file:
         specific_raml_file_pn = os.path.join(git_input_dir, args.file)
         if not os.path.exists(specific_raml_file_pn):
-            logger.critical("Specific RAML file '%s' does not exist in '%s'", specific_raml_file_pn, repo_name)
-            logger.critical("Needs to be pathname relative to top-level, e.g. ramls/item-storage.raml")
+            logger1.critical("Specific RAML file '%s' does not exist in '%s'", specific_raml_file_pn, repo_name)
+            logger1.critical("Needs to be pathname relative to top-level, e.g. ramls/item-storage.raml")
             return 2
 
     # Get the configuration metadata for all repositories that are known to have RAML
@@ -118,17 +120,17 @@ def main():
         config = yaml.safe_load(http_response.text)
     else:
         if not os.path.exists(config_local_pn):
-            logger.critical("Development mode specified (-d) but config file (-c) not found: %s", config_local_pn)
+            logger1.critical("Development mode specified (-d) but config file (-c) not found: %s", config_local_pn)
             return 2
         with open(config_local_pn) as input_fh:
             config = yaml.safe_load(input_fh)
     if config is None:
-        logger.critical("Configuration data was not loaded.")
+        logger1.critical("Configuration data was not loaded.")
         return 2
     if repo_name not in config:
-        logger.warning("No configuration found for repository '%s'", repo_name)
-        logger.warning("See FOLIO-903. Add an entry to api.yml")
-        logger.warning("Attempting default configuration.")
+        logger1.warning("No configuration found for repository '%s'", repo_name)
+        logger1.warning("See FOLIO-903. Add an entry to api.yml")
+        logger1.warning("Attempting default configuration.")
         config[repo_name] = config["default"]
         config[repo_name][0]["files"].remove("dummy")
 
@@ -144,24 +146,24 @@ def main():
     exit_code = 0 # Continue processing to detect various issues, then return the result.
     input_dir = git_input_dir
     for docset in config[repo_name]:
-        logger.info("Investigating and determining configuration: %s", os.path.join(repo_name, docset["directory"]))
+        logger1.info("Investigating and determining configuration: %s", os.path.join(repo_name, docset["directory"]))
         ramls_dir = os.path.join(input_dir, docset["directory"])
-        logger.debug("ramls_dir=%s", ramls_dir)
+        logger1.debug("ramls_dir=%s", ramls_dir)
         version_ramlutil_v1 = True
         if not os.path.exists(ramls_dir):
-            logger.warning("The specified 'ramls' directory not found: %s", os.path.join(repo_name, docset["directory"]))
-            logger.warning("See FOLIO-903. Update entry in api.yml")
-            logger.warning("Attempting default.")
+            logger1.warning("The specified 'ramls' directory not found: %s", os.path.join(repo_name, docset["directory"]))
+            logger1.warning("See FOLIO-903. Update entry in api.yml")
+            logger1.warning("Attempting default.")
             docset["directory"] = config["default"][0]["directory"]
             ramls_dir = os.path.join(input_dir, docset["directory"])
             if not os.path.exists(ramls_dir):
-                logger.critical("The default 'ramls' directory not found: %s/%s", repo_name, docset["directory"])
+                logger1.critical("The default 'ramls' directory not found: %s/%s", repo_name, docset["directory"])
                 return 2
         if docset["ramlutil"] is not None:
             ramlutil_dir = os.path.join(input_dir, docset["ramlutil"])
             if not os.path.exists(ramlutil_dir):
-                logger.warning("The specified 'raml-util' directory not found: %s", os.path.join(repo_name, docset["ramlutil"]))
-                logger.warning("See FOLIO-903. Update entry in api.yml")
+                logger1.warning("The specified 'raml-util' directory not found: %s", os.path.join(repo_name, docset["ramlutil"]))
+                logger1.warning("See FOLIO-903. Update entry in api.yml")
             else:
                 # Detect if new raml-util
                 auth_trait_pn = os.path.join(input_dir, docset["ramlutil"], "traits/auth.raml")
@@ -217,9 +219,9 @@ def main():
             schemas_dir = os.path.join(input_dir, docset["directory"])
         else:
             if not os.path.exists(schemas_dir):
-                logger.warning("The specified 'schemasDirectory' not found: %s", os.path.join(repo_name, docset["schemasDirectory"]))
-                logger.warning("See FOLIO-903. Update entry in api.yml")
-                logger.warning("Attempting default.")
+                logger1.warning("The specified 'schemasDirectory' not found: %s", os.path.join(repo_name, docset["schemasDirectory"]))
+                logger1.warning("See FOLIO-903. Update entry in api.yml")
+                logger1.warning("Attempting default.")
                 schemas_dir = os.path.join(input_dir, docset["directory"])
         if docset["label"] == "shared":
             # If this is the top-level of the shared space, then do not descend
@@ -230,50 +232,50 @@ def main():
         else:
             for root, dirs, files in os.walk(schemas_dir, topdown=True):
                 dirs[:] = [d for d in dirs if d not in excludes]
-                logger.debug("Looking for JSON schema files: %s", root)
+                logger1.debug("Looking for JSON schema files: %s", root)
                 for filename in files:
                     if filename.endswith((".json", ".schema")):
                         schema_pn = os.path.relpath(os.path.join(root, filename), schemas_dir)
                         found_schema_files.append(schema_pn)
-        logger.debug("found_schema_files: %s", found_schema_files)
+        logger1.debug("found_schema_files: %s", found_schema_files)
         for raml_fn in configured_raml_files:
             if raml_fn not in found_raml_files:
-                logger.warning("Configured file not found: %s", raml_fn)
-                logger.warning("Configuration needs to be updated (FOLIO-903).")
+                logger1.warning("Configured file not found: %s", raml_fn)
+                logger1.warning("Configuration needs to be updated (FOLIO-903).")
             else:
                 raml_files.append(raml_fn)
         for raml_fn in found_raml_files:
             if raml_fn not in configured_raml_files:
                 raml_files.append(raml_fn)
-                logger.warning("Missing from configuration: %s", raml_fn)
-                logger.warning("Configuration needs to be updated (FOLIO-903).")
-        logger.debug("configured_raml_files: %s", configured_raml_files)
-        logger.debug("found_raml_files: %s", found_raml_files)
-        logger.debug("raml_files: %s", raml_files)
+                logger1.warning("Missing from configuration: %s", raml_fn)
+                logger1.warning("Configuration needs to be updated (FOLIO-903).")
+        logger1.debug("configured_raml_files: %s", configured_raml_files)
+        logger1.debug("found_raml_files: %s", found_raml_files)
+        logger1.debug("raml_files: %s", raml_files)
         if found_schema_files:
             if args.validate_only:
-                logger.info("Not assessing schema descriptions, as per option '--validate-only'.")
+                logger1.info("Not assessing schema descriptions, as per option '--validate-only'.")
             else:
                 issues_flag = assess_schema_descriptions(schemas_dir, found_schema_files, has_jq)
                 if issues_flag:
                     exit_code = 1
         if args.json_only:
-            logger.info("Not assessing RAML/Schema or examples against schema, as per option '--json-only'.")
+            logger1.info("Not assessing RAML/Schema or examples against schema, as per option '--json-only'.")
             continue
         if not is_schemas_only:
-            logger.info("Assessing RAML files (https://dev.folio.org/guides/raml-cop/):")
+            logger1.info("Assessing RAML files (https://dev.folio.org/guides/raml-cop/):")
             if not raml_files:
-                logger.error("No RAML files found in %s", ramls_dir)
+                logger1.error("No RAML files found in %s", ramls_dir)
                 exit_code = 1
         for raml_fn in raml_files:
             if args.file:
                 if os.path.join(docset["directory"], raml_fn) != args.file:
-                    logger.info("Skipping RAML file: %s", raml_fn)
+                    logger1.info("Skipping RAML file: %s", raml_fn)
                     continue
             input_pn = os.path.join(ramls_dir, raml_fn)
             if not os.path.exists(input_pn):
-                logger.warning("Missing configured input file '%s'", os.path.join(repo_name, raml_fn))
-                logger.warning("Configuration needs to be updated (FOLIO-903).")
+                logger1.warning("Missing configured input file '%s'", os.path.join(repo_name, raml_fn))
+                logger1.warning("Configuration needs to be updated (FOLIO-903).")
                 continue
             # Determine raml version
             version_value = None
@@ -284,18 +286,18 @@ def main():
                         version_value = match.group(1)
                         break
             if not version_value:
-                logger.error("Could not determine RAML version for file '%s' so skipping.", raml_fn)
+                logger1.error("Could not determine RAML version for file '%s' so skipping.", raml_fn)
                 exit_code = 1
                 continue
-            logger.info("Processing RAML v%s file: %s", version_value, raml_fn)
+            logger2.info("Processing RAML v%s file: %s", version_value, raml_fn)
             if version_value != "0.8" and not version_ramlutil_v1:
-                logger.error("The raml-util is not RAML-1.0 version. Update git submodule.")
+                logger1.error("The raml-util is not RAML-1.0 version. Update git submodule.")
                 exit_code = 2
                 continue
             # Now process this RAML file
             # First load the content to extract some details.
             (schemas, issues_flag) = gather_declarations(input_pn, raml_fn, version_value, is_rmb, input_dir, docset["directory"])
-            logger.debug("Found %s declared schemas or types files.", len(schemas))
+            logger1.debug("Found %s declared schemas or types files.", len(schemas))
             if issues_flag:
                 exit_code = 1
             # Ensure each $ref referenced schema file exists, is useable, and is declared in the RAML
@@ -311,30 +313,30 @@ def main():
                     match = re.search(schema_ref_re, line)
                     if match:
                         ref_value = match.group(2)
-                        logger.debug("Found schema $ref '%s' in schema file '%s'", ref_value, schemas[schema])
+                        logger1.debug("Found schema $ref '%s' in schema file '%s'", ref_value, schemas[schema])
                         relative_schema_ref_fn = os.path.normpath(os.path.join(os.path.dirname(schemas[schema]), ref_value))
-                        logger.debug("    relative_schema_ref_fn=%s", relative_schema_ref_fn)
+                        logger1.debug("    relative_schema_ref_fn=%s", relative_schema_ref_fn)
                         relative_schema_ref_pn = os.path.normpath(os.path.join(ramls_dir, relative_schema_ref_fn))
                         if not is_rmb:
-                            logger.debug("Not RMB type, so just report if file not found.")
+                            logger1.debug("Not RMB type, so just report if file not found.")
                             if not os.path.exists(relative_schema_ref_pn):
-                                logger.error("File not found: %s", relative_schema_ref_pn)
-                                logger.error("  via schema $ref '%s' in schema file '%s'", ref_value, schemas[schema])
+                                logger1.error("File not found: %s", relative_schema_ref_pn)
+                                logger1.error("  via schema $ref '%s' in schema file '%s'", ref_value, schemas[schema])
                                 exit_code = 1
                         else:
                             if version_value != "0.8":
-                                #logger.debug("Is RMB >= v20 and 1.0, so report if file not found.")
+                                #logger1.debug("Is RMB >= v20 and 1.0, so report if file not found.")
                                 if not os.path.exists(relative_schema_ref_pn):
-                                    logger.error("File not found: %s", relative_schema_ref_pn)
-                                    logger.error("  via schema $ref '%s' in schema file '%s'", ref_value, schemas[schema])
+                                    logger1.error("File not found: %s", relative_schema_ref_pn)
+                                    logger1.error("  via schema $ref '%s' in schema file '%s'", ref_value, schemas[schema])
                                     exit_code = 1
                             else:
-                                #logger.debug("Is RMB < v20 and 0.8, so report if file not found, and ensure declaration.")
+                                #logger1.debug("Is RMB < v20 and 0.8, so report if file not found, and ensure declaration.")
                                 # RMB < v20 enables $ref in schema to be a pathname, if the position in the filesystem
                                 # and its use in the RAML meets strict conditions.
                                 if not os.path.exists(relative_schema_ref_pn):
-                                    logger.error("File not found: %s", relative_schema_ref_pn)
-                                    logger.error("  via schema $ref '%s' in schema file '%s'", ref_value, schemas[schema])
+                                    logger1.error("File not found: %s", relative_schema_ref_pn)
+                                    logger1.error("  via schema $ref '%s' in schema file '%s'", ref_value, schemas[schema])
                                     exit_code = 1
                                 else:
                                     # This RMB version has an extra bit of weirdness.
@@ -346,36 +348,36 @@ def main():
                                     if "../" in ref_value:
                                         rel_ref_value = ref_value
                                         for x in range(0, schema.count("/")):
-                                            logger.debug("      dot-dot count x=%s", x+1)
+                                            logger1.debug("      dot-dot count x=%s", x+1)
                                             rel_ref_value = re.sub("\.\./", "", rel_ref_value, count=1)
-                                        logger.debug("      rel_ref_value=%s", rel_ref_value)
+                                        logger1.debug("      rel_ref_value=%s", rel_ref_value)
                                         try:
                                             schemas[rel_ref_value]
                                         except KeyError:
-                                            logger.error("The schema reference '%s' defined in '%s' needs to be declared as '%s' in RAML file.", ref_value, schemas[schema], rel_ref_value)
+                                            logger1.error("The schema reference '%s' defined in '%s' needs to be declared as '%s' in RAML file.", ref_value, schemas[schema], rel_ref_value)
                                             exit_code = 1
                                     else:
                                         try:
                                             schemas[ref_value]
                                         except KeyError:
-                                            logger.error("The schema reference '%s' defined in '%s' is not declared in RAML file.", ref_value, schemas[schema])
+                                            logger1.error("The schema reference '%s' defined in '%s' is not declared in RAML file.", ref_value, schemas[schema])
                                             exit_code = 1
             # Sool raml-cop onto it.
             cmd_raml_cop = sh.Command(bin_raml_cop)
             try:
                 cmd_raml_cop(input_pn, no_color=True)
             except sh.ErrorReturnCode_1 as err:
-                logger.error("  raml-cop detected errors with %s:\n%s", raml_fn, err.stdout.decode())
+                logger2.error("  raml-cop detected errors with %s:\n%s", raml_fn, err.stdout.decode())
                 exit_code = 1
             else:
-                logger.info("  raml-cop did not detect any errors with %s", raml_fn)
+                logger2.info("  raml-cop did not detect any errors with %s", raml_fn)
     # Report the outcome
     if exit_code == 1:
-        logger.error("There were processing errors. See list above.")
+        logger1.error("There were processing errors. See list above.")
     elif exit_code == 2:
-        logger.error("There were processing errors. See list above.")
+        logger1.error("There were processing errors. See list above.")
     else:
-        logger.info("Did not detect any errors.")
+        logger1.info("Did not detect any errors.")
     logging.shutdown()
     return exit_code
 
@@ -487,7 +489,7 @@ def assess_schema_descriptions(schemas_dir, schema_files, has_jq):
     """
     Ensure top-level "description" and for each property.
     """
-    logger = logging.getLogger("lint-raml-cop")
+    logger = logging.getLogger("lint-raml-schema")
     logger.info("Assessing schema files (https://dev.folio.org/guides/describe-schema/):")
     logger.info("Found %s JSON schema files under directory '%s'", len(schema_files), schemas_dir)
     issues = False

--- a/lint-raml/yarn.lock
+++ b/lint-raml/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@types/node@^7.0.31":
-  version "7.10.2"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-7.10.2.tgz#a98845168012d7a63a84d50e738829da43bdb0de"
-  integrity sha512-RO4ig5taKmcrU4Rex8ojG1gpwFkjddzug9iPQSDvbewHN9vDpcFewevkaOK+KT+w1LeZnxbgOyfXwV4pxsQ4GQ==
+"@types/node@^9.3.0":
+  version "9.6.49"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-9.6.49.tgz#ab4df6e505db088882c8ce5417ae0bc8cbb7a8a6"
+  integrity sha512-YY0Okyn4QXC4ugJI+Kng5iWjK8A6eIHiQVaGIhJkyn0YL6Iqo0E0tBC8BuhvYcBK87vykBijM5FtMnCqaa5anA==
 
 amdefine@~0.0.4:
   version "0.0.8"
@@ -18,9 +18,9 @@ bignumber.js@4.1.0:
   integrity sha512-eJzYkFYy9L4JzXsbymsFn3p54D+llV27oTQ+ziJG7WFRheJcNZilgVXMG0LoZtlQSKBsJdWtLFqOD0u+U0jZKA==
 
 bluebird@^3.4.6:
-  version "3.5.3"
-  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.3.tgz#7d01c6f9616c9a51ab0f8c549a79dfe6ec33efa7"
-  integrity sha512-/qKPUQlaW1OyR51WeCPBvRnAlnZFUJkCSG5HzGnuIqhgyJtF+T94lFnn33eiazjRm2LAHVy2guNnaq48X9SJuw==
+  version "3.5.5"
+  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.5.tgz#a8d0afd73251effbbd5fe384a77d73003c17a71f"
+  integrity sha512-5am6HnnfN+urzt4yfg7IgTbotDjIT/u8AJpEt0sIU9FtXfVeezXAPKswrG+xKUCOYAINpSdgZVDU6QFh+cuH3w==
 
 camel-case@^3.0.0:
   version "3.0.0"
@@ -30,10 +30,10 @@ camel-case@^3.0.0:
     no-case "^2.2.0"
     upper-case "^1.1.1"
 
-change-case@3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/change-case/-/change-case-3.0.1.tgz#ee5f5ad0415ad1ad9e8072cf49cd4cfa7660a554"
-  integrity sha1-7l9a0EFa0a2egHLPSc1M+nZgpVQ=
+change-case@3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/change-case/-/change-case-3.1.0.tgz#0e611b7edc9952df2e8513b27b42de72647dd17e"
+  integrity sha512-2AZp7uJZbYEzRPsFoa+ijKdvp9zsrnnt6+yFokfwEpeJm0xuJDVoxiRCAaTzyJND8GJkofo2IcKWaUZ/OECVzw==
   dependencies:
     camel-case "^3.0.0"
     constant-case "^2.0.0"
@@ -43,7 +43,7 @@ change-case@3.0.1:
     is-upper-case "^1.1.0"
     lower-case "^1.1.1"
     lower-case-first "^1.0.0"
-    no-case "^2.2.0"
+    no-case "^2.3.2"
     param-case "^2.1.0"
     pascal-case "^2.0.0"
     path-case "^2.1.0"
@@ -60,9 +60,9 @@ colors@^1.1.2:
   integrity sha512-mmGt/1pZqYRjMxB1axhTo16/snVZ5krrKkcmMeVKxzECMMXoCgnvTPp10QgHfcbQZw8Dq2jMNG6je4JlWU0gWg==
 
 commander@^2.7.1, commander@^2.9.0:
-  version "2.19.0"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-2.19.0.tgz#f6198aa84e5b83c46054b94ddedbfed5ee9ff12a"
-  integrity sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg==
+  version "2.20.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.0.tgz#d58bb2b5c1ee8f87b0d340027e9e94e222c5a422"
+  integrity sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==
 
 constant-case@^2.0.0:
   version "2.0.0"
@@ -71,6 +71,11 @@ constant-case@^2.0.0:
   dependencies:
     snake-case "^2.1.0"
     upper-case "^1.1.1"
+
+core-js@^2.5.7:
+  version "2.6.9"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.9.tgz#6b4b214620c834152e179323727fc19741b084f2"
+  integrity sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A==
 
 date-and-time@0.5.0:
   version "0.5.0"
@@ -89,10 +94,10 @@ escape-html@1.0.3:
   resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.3.tgz#0258eae4d3d0c0974de1c169188ef0051d1d1988"
   integrity sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=
 
-fs-extra@4.0.2:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-4.0.2.tgz#f91704c53d1b461f893452b0c307d9997647ab6b"
-  integrity sha1-+RcExT0bRh+JNFKwwwfZmXZHq2s=
+fs-extra@7.0.1:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-7.0.1.tgz#4f189c44aa123b895f722804f55ea23eadc348e9"
+  integrity sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==
   dependencies:
     graceful-fs "^4.1.2"
     jsonfile "^4.0.0"
@@ -111,17 +116,17 @@ header-case@^1.0.0:
     no-case "^2.2.0"
     upper-case "^1.1.3"
 
-http-response-object@2.0.3:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/http-response-object/-/http-response-object-2.0.3.tgz#530a48c3b6b683be2398fc42417f7c54f8b401a8"
-  integrity sha512-qWk3Svyl+SnYYSRuN6m0yiAbmCNBH6Q1HHbOBViEmsrO1TlGYsBSAiI8gDv95wMAV+f4I9JLbUM7gkRTLaFuLQ==
+http-response-object@3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/http-response-object/-/http-response-object-3.0.1.tgz#90174d44c27b5e797cf6efe51a043bc889ae64bf"
+  integrity sha512-6L0Fkd6TozA8kFSfh9Widst0wfza3U1Ex2RjJ6zNDK0vR1U1auUR6jY4Nn2Xl7CCy0ikFmxW1XcspVpb9RvwTg==
   dependencies:
-    "@types/node" "^7.0.31"
+    "@types/node" "^9.3.0"
 
-invariant@2.2.2:
-  version "2.2.2"
-  resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.2.tgz#9e1f56ac0acdb6bf303306f338be3b204ae60360"
-  integrity sha1-nh9WrArNtr8wMwbzOL47IErmA2A=
+invariant@2.2.4:
+  version "2.2.4"
+  resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.4.tgz#610f3c92c9359ce1db616e538008d23ff35158e6"
+  integrity sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==
   dependencies:
     loose-envify "^1.0.0"
 
@@ -192,12 +197,12 @@ know-your-http-well@0.5.0:
   dependencies:
     amdefine "~0.0.4"
 
-lodash.get@^4.0.0:
+lodash.get@^4.0.0, lodash.get@^4.4.2:
   version "4.4.2"
   resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
   integrity sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=
 
-lodash.isequal@^4.0.0:
+lodash.isequal@^4.0.0, lodash.isequal@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.isequal/-/lodash.isequal-4.5.0.tgz#415c4478f2bcc30120c22ce10ed3226f7d3e18e0"
   integrity sha1-QVxEePK8wwEgwizhDtMib30+GOA=
@@ -231,10 +236,10 @@ lrucache@1.0.3:
   resolved "https://registry.yarnpkg.com/lrucache/-/lrucache-1.0.3.tgz#3b1ded0d1ba82e188b9bdaba9eee6486f864a434"
   integrity sha1-Ox3tDRuoLhiLm9q6nu5khvhkpDQ=
 
-media-typer@0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/media-typer/-/media-typer-0.3.0.tgz#8710d7af0aa626f8fffa1ce00168545263255748"
-  integrity sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=
+media-typer@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/media-typer/-/media-typer-1.0.1.tgz#e39d677e19a011c52d2681f430d1adafb299dd41"
+  integrity sha512-v42gdPIuqYCoDVH5OiaKsVrv6aJqdMWJzl8KCyDs/KeDyBveYp3Wxq4UWJfsWjkSZUNC0xlLfDlLCPa1h/oo+g==
 
 minimist@0.0.8:
   version "0.0.8"
@@ -248,7 +253,7 @@ mkdirp@0.5.1:
   dependencies:
     minimist "0.0.8"
 
-no-case@^2.2.0:
+no-case@^2.2.0, no-case@^2.3.2:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/no-case/-/no-case-2.3.2.tgz#60b813396be39b3f1288a4c1ed5d1e7d28b464ac"
   integrity sha512-rmTZ9kz+f3rCvK2TD1Ue/oZlns7OGoIWP4fc3llxxRXlOkHKoWPPWJOfFYpITabSow43QJbRIoHQXtt10VldyQ==
@@ -282,35 +287,35 @@ pluralize@7.0.0:
   resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-7.0.0.tgz#298b89df8b93b0221dbf421ad2b1b1ea23fc6777"
   integrity sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==
 
-promise-polyfill@6.0.2:
-  version "6.0.2"
-  resolved "https://registry.yarnpkg.com/promise-polyfill/-/promise-polyfill-6.0.2.tgz#d9c86d3dc4dc2df9016e88946defd69b49b41162"
-  integrity sha1-2chtPcTcLfkBboiUbe/Wm0m0EWI=
+promise-polyfill@8.1.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/promise-polyfill/-/promise-polyfill-8.1.0.tgz#30059da54d1358ce905ac581f287e184aedf995d"
+  integrity sha512-OzSf6gcCUQ01byV4BgwyUCswlaQQ6gzXc23aLQWhicvfX9kfsUiUhgt3CCQej8jDnl8/PhGF31JdHX2/MzF3WA==
 
-q@1.5.0:
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/q/-/q-1.5.0.tgz#dd01bac9d06d30e6f219aecb8253ee9ebdc308f1"
-  integrity sha1-3QG6ydBtMObyGa7LglPunr3DCPE=
+q@1.5.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/q/-/q-1.5.1.tgz#7e32f75b41381291d04611f1bf14109ac00651d7"
+  integrity sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=
 
 raml-1-parser@^1.1.15:
-  version "1.1.50"
-  resolved "https://registry.yarnpkg.com/raml-1-parser/-/raml-1-parser-1.1.50.tgz#9d5a10c0b31559591a821a4f0545160e1c32425b"
-  integrity sha512-zHvR3ao1cLiVNl88t3y+TH1eIgFVRngByljT1HSD4bB3G4wriLcK/gGhs632VK5pVqBiFGWodN6CatRRP8LWRw==
+  version "1.1.52"
+  resolved "https://registry.yarnpkg.com/raml-1-parser/-/raml-1-parser-1.1.52.tgz#651dde7b6e642a973b9cc5b1e4b738874d6dbe92"
+  integrity sha512-TRBCvLoZo2pw4oGPztwaIGxTMCASoKoYmTa2KVvXUTFSUFuiJk1DvgcwXAqKQvwKyH4T1NhMt3z09n3eURzcrQ==
   dependencies:
-    change-case "3.0.1"
-    fs-extra "4.0.2"
-    http-response-object "2.0.3"
-    invariant "2.2.2"
+    change-case "3.1.0"
+    fs-extra "7.0.1"
+    http-response-object "3.0.1"
+    invariant "2.2.4"
     json-path "0.1.3"
     json-schema-compatibility "1.1.0"
     json-stable-stringify "1.0.1"
     loophole "1.1.0"
     lrucache "1.0.3"
-    media-typer "0.3.0"
+    media-typer "1.0.1"
     mkdirp "0.5.1"
     pluralize "7.0.0"
-    promise-polyfill "6.0.2"
-    q "1.5.0"
+    promise-polyfill "8.1.0"
+    q "1.5.1"
     raml-definition-system "0.0.87"
     ts-model "0.0.18"
     underscore "1.9.1"
@@ -319,7 +324,7 @@ raml-1-parser@^1.1.15:
     xmldom "0.1.27"
     xmlhttprequest "1.8.0"
     yaml-ast-parser "0.0.43"
-    z-schema "3.21.0"
+    z-schema "4.0.1"
 
 raml-cop@^5.0.0:
   version "5.0.0"
@@ -448,10 +453,10 @@ urlsafe-base64@^1.0.0:
   resolved "https://registry.yarnpkg.com/urlsafe-base64/-/urlsafe-base64-1.0.0.tgz#23f89069a6c62f46cf3a1d3b00169cefb90be0c6"
   integrity sha1-I/iQaabGL0bPOh07ABac77kL4MY=
 
-validator@^10.0.0:
-  version "10.9.0"
-  resolved "https://registry.yarnpkg.com/validator/-/validator-10.9.0.tgz#d10c11673b5061fb7ccf4c1114412411b2bac2a8"
-  integrity sha512-hZJcZSWz9poXBlAkjjcsNAdrZ6JbjD3kWlNjq/+vE7RLLS/+8PAj3qVVwrwsOz/WL8jPmZ1hYkRvtlUeZAm4ug==
+validator@^10.0.0, validator@^10.11.0:
+  version "10.11.0"
+  resolved "https://registry.yarnpkg.com/validator/-/validator-10.11.0.tgz#003108ea6e9a9874d31ccc9e5006856ccd76b228"
+  integrity sha512-X/p3UZerAIsbBfN/IwahhYaBbY68EN/UQBWHtsbXGT5bfrH/p4NQzUCG1kF/rtKaNpnJ7jAu6NGTdSNtyNIXMw==
 
 xhr2@0.1.4:
   version "0.1.4"
@@ -499,5 +504,17 @@ z-schema@3.21.0:
     lodash.get "^4.0.0"
     lodash.isequal "^4.0.0"
     validator "^10.0.0"
+  optionalDependencies:
+    commander "^2.7.1"
+
+z-schema@4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/z-schema/-/z-schema-4.0.1.tgz#e4088c1616c8a2df82efcd0a20434bd89f8e9415"
+  integrity sha512-eYi6JZ3iq01zIpDLXbz9oQrstXVQ6dtR0u6nXGsCG+dDDtcDi7p2r2zCrih5n6brb35b+ad7H/mSimV8KckxCQ==
+  dependencies:
+    core-js "^2.5.7"
+    lodash.get "^4.4.2"
+    lodash.isequal "^4.5.0"
+    validator "^10.11.0"
   optionalDependencies:
     commander "^2.7.1"


### PR DESCRIPTION
Update dependencies: raml-1-parser (raml-js-parser-2) and z-schema, etc.
Separate log messages for processing schema.
Better handle broken YAML.