### PR TITLE
Use JRE (not JDK) for Dockerfile.alpine-jre-openjdk8

### DIFF
--- a/folio-java-docker/openjdk8/Dockerfile.alpine-jre-openjdk8
+++ b/folio-java-docker/openjdk8/Dockerfile.alpine-jre-openjdk8
@@ -10,7 +10,7 @@ ENV JAVA_APP_DIR /usr/verticles
 RUN apk add --update \
     curl \
     bash \
-    openjdk8 \
+    openjdk8-jre \
  && rm /var/cache/apk/* \
  && echo "securerandom.source=file:/dev/urandom" >> /usr/lib/jvm/default-jvm/jre/lib/security/java.security
 


### PR DESCRIPTION
The full JDK is not needed, only the JRE. This saves 19 MB installed size.

The name Dockerfile.alpine-jre-openjdk8 suggests that it is only JRE.

The other Dockerfile Dockerfile.openjdk8-jre also uses JRE only ("FROM openjdk:8-jre").