### PR TITLE
FOLIO-1497 lint-raml: Update to raml-1-parser 1.1.63

### DIFF
--- a/lint-raml/yarn.lock
+++ b/lint-raml/yarn.lock
@@ -222,17 +222,10 @@ media-typer@1.1.0:
   resolved "https://registry.yarnpkg.com/media-typer/-/media-typer-1.1.0.tgz#6ab74b8f2d3320f2064b2a87a38e7931ff3a5561"
   integrity sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==
 
-minimist@0.0.8:
-  version "0.0.8"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
-  integrity sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=
-
-mkdirp@0.5.1:
-  version "0.5.1"
-  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
-  integrity sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=
-  dependencies:
-    minimist "0.0.8"
+mkdirp@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.3.tgz#4cf2e30ad45959dddea53ad97d518b6c8205e1ea"
+  integrity sha512-6uCP4Qc0sWsgMLy1EOqqS/3rjDHOEnsStVr/4vtAIK2Y5i2kA7lFFejYrpIyiN9w0pYf4ckeCYT9f1r1P9KX5g==
 
 no-case@^3.0.3:
   version "3.0.3"
@@ -282,9 +275,9 @@ q@1.5.1:
   integrity sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=
 
 raml-1-parser@^1.1.15:
-  version "1.1.61"
-  resolved "https://registry.yarnpkg.com/raml-1-parser/-/raml-1-parser-1.1.61.tgz#218be6c32bcee390ade13406b7a5174ab137c439"
-  integrity sha512-hyjlYoyehZUsd2acWfo5g+SFNYAnVoBa04sbFGihA42F43yja0AWoKe5EBrIQkqXq4JHB0HtbVThVTPwb7urGg==
+  version "1.1.63"
+  resolved "https://registry.yarnpkg.com/raml-1-parser/-/raml-1-parser-1.1.63.tgz#e741613956413ee54dd8faeae0d0b862988d8cb2"
+  integrity sha512-umuEiINM4PFIgvHnn2VDqejpBtrbOT7x8UWjqj1ZjOR07SSBLvxbzUfOIBVrgzvEr+HJ4SdmUX/AzNAEN1P7Lw==
   dependencies:
     change-case "^4.1.1"
     fs-extra "8.1.0"
@@ -296,13 +289,13 @@ raml-1-parser@^1.1.15:
     loophole "1.1.0"
     lrucache "1.0.3"
     media-typer "1.1.0"
-    mkdirp "0.5.1"
+    mkdirp "^1.0.3"
     pluralize "8.0.0"
     promise-polyfill "8.1.3"
     q "1.5.1"
     raml-definition-system "^0.0.93"
     ts-model "0.0.18"
-    underscore "1.9.1"
+    underscore "^1.9.2"
     upper-case-first "^2.0.1"
     urlsafe-base64 "1.0.0"
     xhr2 "0.2.0"


### PR DESCRIPTION
 Update to raml-1-parser 1.1.63 and associated dependencies
