### PR TITLE
Add curl so curl based health check can pass

### DIFF
--- a/folio-java-docker/openjdk11/Dockerfile
+++ b/folio-java-docker/openjdk11/Dockerfile
@@ -11,6 +11,7 @@ ENV JAVA_APP_DIR=/usr/verticles \
 # /dev/urandom is used as random source, which is perfectly safe
 # according to http://www.2uo.de/myths-about-urandom/
 RUN apk add --no-cache \
+    curl \
     openjdk11-jre-headless \
  && echo "securerandom.source=file:/dev/urandom" >> /usr/lib/jvm/default-jvm/jre/lib/security/java.security
 


### PR DESCRIPTION
Add curl to base image since we use curl to test health check. Right now, Okapi Java 11 build fails because of that. See comments here https://issues.folio.org/browse/FOLIO-2637?focusedCommentId=84566&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-84566