### PR TITLE
add missing doc to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
-A collection of tools and various bits used primarily by FOLIO CI to build and deploy FOLIO artifacts.   
+A collection of tools and various bits used primarily by FOLIO CI to build and deploy FOLIO artifacts.
 
- * generate-api-docs - For generating API docs in HTML from RAML files 
+ * add-users - Add users with extensive permission sets.
+ * cql_log_parse - For parsing cql-to-sql translations from Okapi log files.
+ * generate-api-docs - For generating API docs in HTML from RAML files
  * jenkins-slave-docker - Dockerfiles used for FOLIO builds in Jenkins.
  * lint-raml - Various processing tools to assist RAML and schema maintenance.
  * packaging - Experimental debian packaging scripts using Docker and git-buildpackage.
- * cql_log_parse - For parsing cql-to-sql translations from Okapi log files.
  * vufind-indexer - Experimental indexer for ingesting instance records to Solr

--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@ A collection of tools and various bits used primarily by FOLIO CI to build and d
 
  * add-users - Add users with extensive permission sets.
  * cql_log_parse - For parsing cql-to-sql translations from Okapi log files.
+ * folio-java-docker - Config files for the Docker image for java-based FOLIO applications.
  * generate-api-docs - For generating API docs in HTML from RAML files
+ * interface-dependents - Collect list of modules dependent upon an interface
  * jenkins-slave-docker - Dockerfiles used for FOLIO builds in Jenkins.
  * lint-raml - Various processing tools to assist RAML and schema maintenance.
  * packaging - Experimental debian packaging scripts using Docker and git-buildpackage.


### PR DESCRIPTION
Add missing descriptions to the readme: 

* add-users - Add users with extensive permission sets.
* folio-java-docker - Config files for the Docker image for java-based FOLIO applications.
* interface-dependents - Collect list of modules dependent upon an interface