### PR TITLE
FOLIO-2926: jenkins-slave-docker: Deprecate xenial-java-8

### DIFF
--- a/jenkins-slave-docker/Dockerfile.xenial-java-8
+++ b/jenkins-slave-docker/Dockerfile.xenial-java-8
@@ -1,5 +1,7 @@
 FROM ubuntu:xenial
 
+# 2020-12-30: FOLIO-2926: Deprecated the 1.x series. Use the "java-11" instead.
+
 # setup SSH server
 RUN apt-get update \
     && apt-get install --no-install-recommends -y openssh-server \

--- a/jenkins-slave-docker/NEWS.md
+++ b/jenkins-slave-docker/NEWS.md
@@ -6,10 +6,6 @@
 
 * Fix wget FOLIO-2923
 
-## 1.3.0 2020-12-18
-
-* Fix wget FOLIO-2923
-
 ## 2.4.0 2020-12-09
 
 * Add api-lint

--- a/jenkins-slave-docker/NEWS.md
+++ b/jenkins-slave-docker/NEWS.md
@@ -30,6 +30,11 @@
 
 * Java 11
 
+## 1.2.2 latest 2020-04-30
+
+* Java 8
+* Deprecated: This is the final of the 1.x series.
+
 ## 1.2.1 2020-04-24
 
 * Utilise new stripes-cli v1.15.1 FOLIO-2572,STCLI-148

--- a/jenkins-slave-docker/README.md
+++ b/jenkins-slave-docker/README.md
@@ -3,7 +3,7 @@ tools needed to build and deploy FOLIO artifacts for https://github.com/folio-or
 
 The image can be deployed as either Jenkins slave instances or as personal development
 environments for FOLIO.  The image is primarily used by FOLIO CI and is available
-in the FOLIO CI repository at Docker Hub - https://hub.docker.com/u/folioci/dashboard/
+in the FOLIO CI repository at Docker Hub - https://hub.docker.com/u/folioci
 
 The image is based on the jenkinsci/ssh-slave images including authentication support
 using a SSH key pair and as well as use of the entrypoint script, 'setup-ssh' from the
@@ -39,6 +39,7 @@ Example build and run commands for the image:
 ## Upgrading this image
 * Pick a new version number (Check NEWS.md or hub.docker.com for the latest tag)
 * List changes in the NEWS.md file
-* Build and tag the new image with the new version tag and "latest". Jenkins will pull the image tagged "latest".
+* Build and tag the new image with the new version tag and "java-11". Jenkins will pull the image tagged "java-11".
+* 2020-12-30: The "latest" tag refers to the deprecated 1.x series "java-8" image.
 
-If it's necessary to revert to an older image, use docker pull to get an older version, tag it as latest and push it back up.
+If it's necessary to revert to an older image, use docker pull to get an older version, tag it as "java-11" and push it back up.


### PR DESCRIPTION
Use "java-11" instead.