### PR TITLE
STCOR-497: Rebuild jenkins-slave-all with Node 12.20.1

### DIFF
--- a/jenkins-slave-docker/NEWS.md
+++ b/jenkins-slave-docker/NEWS.md
@@ -1,3 +1,9 @@
+## 2.6.1 2021-01-05
+
+* Rebuild image to upgrade Node (now 12.20.1 was 12.20.0) fixing
+  TLS, HTTP and OpenSSL security vulnerabilities (CVE-2020-8265, CVE-2020-8287, CVE-2020-1971)
+  https://issues.folio.org/browse/STCOR-497
+
 ## 2.6.0 2020-12-29
 
 * add libyaz5 FOLIO-2925

--- a/jenkins-slave-docker/README.md
+++ b/jenkins-slave-docker/README.md
@@ -3,7 +3,7 @@ tools needed to build and deploy FOLIO artifacts for https://github.com/folio-or
 
 The image can be deployed as either Jenkins slave instances or as personal development
 environments for FOLIO.  The image is primarily used by FOLIO CI and is available
-in the FOLIO CI repository at Docker Hub - https://hub.docker.com/u/folioci
+in the FOLIO CI repository at Docker Hub - https://hub.docker.com/r/folioci/jenkins-slave-all
 
 The image is based on the jenkinsci/ssh-slave images including authentication support
 using a SSH key pair and as well as use of the entrypoint script, 'setup-ssh' from the
@@ -37,7 +37,9 @@ Example build and run commands for the image:
 ```
 
 ## Upgrading this image
-* Pick a new version number (Check NEWS.md or hub.docker.com for the latest tag)
+* Pick a new version number (Check [NEWS.md](NEWS.md) or
+  https://hub.docker.com/r/folioci/jenkins-slave-all/tags?page=1&ordering=last_updated
+  for the latest tag)
 * List changes in the NEWS.md file
 * Build and tag the new image with the new version tag and "java-11". Jenkins will pull the image tagged "java-11".
 * 2020-12-30: The "latest" tag refers to the deprecated 1.x series "java-8" image.


### PR DESCRIPTION
Rebuild image to upgrade Node (now 12.20.1 was 12.20.0) fixing
TLS, HTTP and OpenSSL security vulnerabilities (CVE-2020-8265, CVE-2020-8287, CVE-2020-1971)
https://issues.folio.org/browse/STCOR-497