### PR TITLE
FOLIO-2904 node script to purge loan data

### DIFF
--- a/clear-loans/DAO.js
+++ b/clear-loans/DAO.js
@@ -1,0 +1,137 @@
+/**
+ * data access methods; they return promises
+ */
+class DAO
+{
+  /** size of batches to retrieve */
+  limit = 100;
+
+
+  /**
+   * retrieve all open loans, in $limit sized-batches; return a single array
+   */
+  getOpenLoans()
+  {
+    return this.okapi.getAll('/circulation/loans?query=status.name=="Open"', 'loans', this.limit);
+  }
+
+  /**
+   * check in the given loan at the given service point
+   */
+  checkin(loan, sp)
+  {
+    if (loan.item.barcode) {
+      const body = {
+        itemBarcode: loan.item.barcode,
+        servicePointId: sp.id,
+        checkInDate: new Date().toISOString(),
+      };
+
+      return this.okapi.post('/circulation/check-in-by-barcode', body).then(res => res.json);
+    }
+
+    throw `Could not renew loan ${loan.id}; the item lacked a barcode.`;
+  }
+
+  /**
+   * retrieve up to 100 service points
+   */
+  getServicePoints()
+  {
+    return this.okapi.get('/service-points?limit=100').then(res => {
+      return res.json.servicepoints;
+    });
+  }
+
+  /**
+   * retrieve all accounts by status, in $limit sized-batches; return a single array
+   */
+  getAccounts(status) {
+    return this.okapi.getAll(`/accounts?query=status.name=="${status}"`, 'accounts', this.limit);
+  }
+
+  /**
+   * transfer the given account from the given service point with the
+   * user-name "Automated Process".
+   */
+  transferAccount(account, sp)
+  {
+    const body = {
+      amount: `${account.remaining}`,
+      notifyPatron: false,
+      servicePointId: sp.id,
+      userName: "Automated Process",
+      paymentMethod: "Cash",
+    };
+
+    return this.okapi.post(`/accounts/${account.id}/transfer`, body).then(res => res.json);
+  }
+
+  /**
+   * remove the given account from
+   */
+  removeAccount(account)
+  {
+    return this.okapi.delete(`/accounts/${account.id}`);
+  }
+
+  /**
+   * get cancellation reasons matching name
+   */
+  getCancellationReasons(name)
+  {
+    return this.okapi.get(`/cancellation-reason-storage/cancellation-reasons?query=name=="${name}"&limit=100`).then(res => {
+      return res.json.cancellationReasons;
+    });
+  }
+
+  /**
+   * get requests given a type and status in $limit-sized batches; return a single array
+   */
+  getRequests(type, status)
+  {
+    return this.okapi.get(`/request-storage/requests?query=requestType==${type} and status=="${status}"`, 'requests', this.limit);
+  }
+
+  /**
+   * cancel a request (change its status to "Closed - Cancelled") with the
+   * given service point and reason. pull the cancelledByUserId value from
+   * this.okapi.
+   */
+  cancelRequest(request, sp, reason)
+  {
+    const body = {
+      ...request,
+      cancelledByUserId: this.okapi.userInfo.user.id,
+      cancellationReasonId: reason.id,
+      cancellationAdditionalInformation: '',
+      cancelledDate: new Date().toISOString(),
+      status: 'Closed - Cancelled',
+    }
+
+    return this.okapi.put(`/circulation/requests/${request.id}`, body).then(res => res.json);
+  }
+
+  /**
+   * get non-anonymized, closed loans in $limit-sized batches; return a single array.
+   */
+  getNonAnonymizedClosedLoans()
+  {
+    return this.okapi.get('/circulation/loans?query=status.name==Closed and userId=""', 'loans', this.limit);
+  }
+
+  /**
+   * anonymize loans for the given user-id.
+   */
+  anonymizeLoans(userId)
+  {
+    return this.okapi.post(`/loan-anonymization/by-user/${userId}`);
+  }
+
+  constructor(okapi)
+  {
+    this.okapi = okapi;
+  }
+}
+
+export default DAO;

--- a/clear-loans/README.md
+++ b/clear-loans/README.md
@@ -1,0 +1,21 @@
+## purge loan, fee/fine, and request data
+
+### details
+
+1. check in all outstanding loans (this will clear patron blocks due to
+   items aged to lost; it will also generate lots of fee/fines records)
+2. transfer all outstanding fee/fine records (this will close all open fee/fines)
+3. cancel all Page requests with request status Open- Not yet filled
+4. anonymize all closed loans
+5. delete all closed fee/fines
+
+### usage
+```
+node $0 --username <u> --password <p> --tenant <t> --hostname <h> --port <p>
+node $0 --username <u> --password <p> --tenant <t> --okapi <http...>
+```
+where username, password, and tenant are credentials for signing into
+the okapi instance available at hostname. Given a hostname via `--hostname`,
+handle all requests over https. Given a URL via `--okapi`, parse the value
+and determine whether to handle requests with http or https based on the
+protocol.

--- a/clear-loans/index.js
+++ b/clear-loans/index.js
@@ -155,8 +155,7 @@ class ClearLoans
       .then((sp) => this.transferAccounts(sp))
       .then((sp) => this.cancelOpenPageRequests(sp))
       .then(()   => this.anonymizeClosedLoans())
-      //@@ failing right now do to a missing module permisssion in mod-feesfines
-      // .then(()   => this.removeClosedAccounts())
+      .then(()   => this.removeClosedAccounts())
       .then(()   => {
         console.log('Done!');
       })

--- a/clear-loans/index.js
+++ b/clear-loans/index.js
@@ -1,0 +1,179 @@
+import { OkapiRequest } from '../okapi-request/index.js';
+import DAO from './DAO.js';
+
+
+/**
+ * 1. check in all outstanding loans (this will clear patron blocks due to
+ *    items aged to lost; it will also generate lots of fee/fines records)
+ * 2. transfer all outstanding fee/fine records (this will close all open fee/fines)
+ * 3. cancel all Page requests with request status "Open - Not yet filled"
+ * 4. anonymize all closed loans
+ * 5. delete all closed fee/fines
+ *
+ */
+class ClearLoans
+{
+  /**
+   * retrieve the first service point
+   */
+  getServicePoint()
+  {
+    console.log('retrieving service point...')
+    return this.dao.getServicePoints().then(res => {
+      if (res.length) {
+        return res[0];
+      }
+
+      throw "Could not retrieve any service points!";
+    });
+  }
+
+
+  /**
+   * retrieve single cancellation-reason by name
+   */
+  getCancellationReason(name)
+  {
+    console.log('retrieving cancellation reason...')
+    return this.dao.getCancellationReasons(name).then(res => {
+      if (res.length && res.length === 1) {
+        return res[0];
+      }
+
+      throw "Could not retrieve cancellation reasons!";
+    });
+  }
+
+
+  /**
+   * retrieve open loans, then check them in at the given service point.
+   * return the service point.
+   */
+  checkInLoans(sp)
+  {
+    console.log('checking in loans...')
+    return this.dao.getOpenLoans().then((loans) => {
+      if (loans && Array.isArray(loans) && loans.length > 0) {
+        return this.okapi.eachPromise(loans, (l) => {
+          return this.dao.checkin(l, sp).then((cl) => {
+            console.log(`\tchecked in ${cl.item.barcode}`);
+          })
+        });
+      }
+    })
+    .then(() => sp);
+  }
+
+
+  /**
+   * retrieve open accounts, then transfer them at thet given service point.
+   * return the service point.
+   */
+  transferAccounts(sp)
+  {
+    console.log('transfer outstanding fees/fines')
+    return this.dao.getAccounts('Open').then((accounts) => {
+      if (accounts && Array.isArray(accounts) && accounts.length > 0) {
+        return this.okapi.eachPromise(accounts, (account) => {
+          return this.dao.transferAccount(account, sp).then((ta) => {
+            console.log(`\ttransfered $${ta.amount} for ${ta.accountId}`);
+          });
+        });
+      }
+    })
+    .then(() => sp);
+  }
+
+
+  /**
+   * Cancel open page requests. Return the service point.
+   */
+  cancelOpenPageRequests(sp)
+  {
+    console.log('cancel "Open - not yet filled" page requests')
+    return this.getCancellationReason('Other').then(reason => {
+      return this.dao.getRequests("Page", "Open - Not yet filled").then((requests) => {
+        if (requests && Array.isArray(requests) && requests.length > 0) {
+          return this.okapi.eachPromise(requests, (r) => {
+            return this.dao.cancelRequest(r, sp, reason).then((cr) => {
+              console.log(`\tcancelled request for ${r.item.barcode}`);
+            })
+          });
+        }
+      })
+      .then(() => sp);
+    });
+  }
+
+  /**
+   * anonymize closed loans
+   */
+  anonymizeClosedLoans()
+  {
+    console.log('anonymize closed loans')
+    return this.dao.getNonAnonymizedClosedLoans().then((loans) => {
+      if (loans && Array.isArray(loans) && loans.length > 0) {
+        const userIds = Array.from(new Set(loans.map(l => l.userId)));
+        return this.okapi.eachPromise(userIds, (id) => {
+          return this.dao.anonymizeLoans(id).then(() => {
+            console.log(`\tanonymized loans for ${id}`);
+          })
+        });
+      }
+    });
+  }
+
+  /**
+   * remove closed accounts
+   */
+  removeClosedAccounts()
+  {
+    console.log('delete closed fee/fines')
+    return this.dao.getAccounts('Closed').then((accounts) => {
+      if (accounts && Array.isArray(accounts) && accounts.length > 0) {
+        return this.okapi.eachPromise(accounts, (account) => {
+          console.log(`deleteing ${account.id}`)
+          return this.dao.removeAccount(account).then(() => {
+            console.log(`\tremoved $${account}`);
+          });
+        });
+      }
+    });
+  }
+
+
+
+  async main() {
+    try {
+      this.okapi = new OkapiRequest(process.argv);
+      this.dao = new DAO(this.okapi);
+
+      this.okapi.login()
+      .then(()   => this.getServicePoint())
+      .then((sp) => this.checkInLoans(sp))
+      .then((sp) => this.transferAccounts(sp))
+      .then((sp) => this.cancelOpenPageRequests(sp))
+      .then(()   => this.anonymizeClosedLoans())
+      //@@ failing right now do to a missing module permisssion in mod-feesfines
+      // .then(()   => this.removeClosedAccounts())
+      .then(()   => {
+        console.log('Done!');
+      })
+      .catch(e => {
+        if (e.statusCode && e.body) {
+          console.error(`(${e.statusCode}): ${e.body}`);
+        }
+        else {
+          console.error(e);
+        }
+      });
+    }
+    catch (e) {
+      console.error("Unhandled exception:", e);
+    }
+  }
+
+}
+
+const cl = new ClearLoans();
+cl.main();

--- a/clear-loans/index.js
+++ b/clear-loans/index.js
@@ -143,7 +143,8 @@ class ClearLoans
 
 
 
-  async main() {
+  main()
+  {
     try {
       this.okapi = new OkapiRequest(process.argv);
       this.dao = new DAO(this.okapi);
@@ -172,8 +173,6 @@ class ClearLoans
       console.error("Unhandled exception:", e);
     }
   }
-
 }
 
-const cl = new ClearLoans();
-cl.main();
+(new ClearLoans()).main();

--- a/clear-loans/package.json
+++ b/clear-loans/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "clear-loans",
+  "type": "module",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC"
+}

--- a/okapi-request/README.md
+++ b/okapi-request/README.md
@@ -1,0 +1,29 @@
+## A dependency-less Okapi request library for use in node-based scripts
+
+### OkapiRequest
+
+The `OkapiRequest` class provides the following functions that return Promises:
+
+* `login()`
+* `get(path)`
+* `getAll(path, object-name, batch-size)`
+* `post(path, {})`
+* `put(path, {})`
+* `delete(path)`
+
+The constructor takes an array and should be called like
+```
+const o = new OkapiRequest(['--username', 'some-u', '--password', 'some-pw', ...])
+```
+Where the `--` keys include the following: `username`, `password`, `tenant`,
+and either (`hostname` and `port`) or (`okapi`).
+
+### usage
+
+```
+const okapi = new OkapiRequest(process.argv);
+okapi.login()
+  .then(() => okapi.get('/some/endpoint'))
+  .then((result) => ...)
+  .catch(...);
+```

--- a/okapi-request/index.js
+++ b/okapi-request/index.js
@@ -1,0 +1,1 @@
+export { default as OkapiRequest } from './lib/OkapiRequest.js';

--- a/okapi-request/lib/OkapiRequest.js
+++ b/okapi-request/lib/OkapiRequest.js
@@ -1,0 +1,304 @@
+import https from 'https';
+import http from 'http';
+
+/**
+ * OkapiRequest
+ * A dependency-less Okapi request library for use in node-based scripts.
+ *
+ * The constructor expects an array of key-value pairs of arguments
+ * containing, at least the following:
+ *     --username [username]
+ *     --password [password]
+ *     --tenant [tenant]
+ * and either
+ *     --okapi [fully-qualified hostname]
+ * or
+ *     --hostname [hostname]
+ *     --port [port]
+ *
+ * Use it like this:
+ *     const okapi = new OkapiRequest(process.argv);
+ *     okapi.login()
+ *     .then(() => okapi.get('/some/endpoint'))
+ *     .then((result) => ...)
+ *     .catch(...);
+ *
+ */
+class OkapiRequest
+{
+  /** information about the authenticated user; populated by this.login() */
+  userInfo = null;
+
+  // request-related details, e.g. hostname, headers, etc
+  // internal use only:
+  requestOptions = {
+    "options": {
+      "method": "POST",
+      "hostname": "",
+      "path": "",
+      "headers": {
+        "Content-type": "application/json",
+        "cache-control": "no-cache",
+        "accept": "application/json"
+      },
+    },
+    "handler": undefined,
+  };
+
+
+  /**
+   * request
+   * send a request to Okapi; return a Promise containing the response
+   *
+   * @arg path string, e.g. /foo/bar/bat
+   * @arg body object, to be stringified in JSON.stringify(body)
+   * @arg method string, one of GET, POST, PUT, DELETE
+   */
+  request(path, body, method)
+  {
+    return new Promise((resolve, reject) => {
+      const thePath = 0 === path.indexOf('/') ? path : `/${path}`;
+      const opts = Object.assign({}, this.requestOptions.options, { path: encodeURI(thePath), method });
+      let req = this.requestOptions.handler.request(opts, (res) => {
+        const chunks = [];
+        res.on("data", function (chunk) {
+          chunks.push(chunk);
+        });
+
+        res.on("end", function () {
+          res.body = chunks.join("")
+          if (res.statusCode >= 200 && res.statusCode < 300) {
+            if (res.body) {
+              res.json = JSON.parse(res.body);
+            }
+            resolve(res);
+          } else {
+            reject(res);
+          }
+        });
+      })
+      .on('error', function(e) {
+        reject(e);
+      });
+
+      try {
+        if (body) {
+          req.write(JSON.stringify(body));
+        }
+        req.end();
+      }
+      catch(e) {
+         reject(e);
+      }
+    });
+  }
+
+
+  /**
+   * processArgs
+   * parse the CLI; throw if a required arg is missing
+   *
+   * "Usage: node " + __filename + " --username <u> --password <p> --tenant <t> --hostname <h> [--port <p>]"
+   * "Usage: node " + __filename + " --username <u> --password <p> --tenant <t> --okapi <o>"
+   * "An Okapi URL will parse to values for --hostname and --port."
+   *
+   * @arg [] args CLI arguments
+   * @return {} object shaped like { username, password, okapi, tenant, pesets }
+   */
+  processArgs(args)
+  {
+    /**
+     * handleHostname
+     * set options.hostname; assume https.
+     * @arg string a hostname such as example.com
+     */
+    const handleHostname = (i, config) => {
+      config.hostname = i;
+
+      this.requestOptions.handler = https;
+      this.requestOptions.options.hostname = i;
+    };
+
+    /**
+     * handlePort
+     * set options.port; assume https for 443, http otherwise.
+     * @arg string a string interpretable as a base-10 integer
+     */
+    const handlePort = (i, config) => {
+      const v = Number.parseInt(i, 10);
+      if (! isNaN(v)) {
+        this.requestOptions.options.port = v;
+        this.requestOptions.handler = (i === "443") ? https : http;
+      } else {
+        throw `The port "${i}" is not a valid number.`;
+      }
+    };
+
+    /**
+     * handleOkapi
+     * set options.hostname and optionally options.port. Configure the request
+     * handler based on the URL prefix (http or https), but note this will be
+     * overriden by the port handler if a port is present.
+     * @arg string a URL, e.g. https://www.example.edu
+     */
+    const handleOkapi = (i, config) => {
+      this.requestOptions.handler = (0 === i.indexOf('https')) ? https : http;
+
+      const matches = i.match(/^http[s]?:\/\/([^:/]+):?([0-9]+)?/);
+      if (matches && matches.length >= 2) {
+        config.hostname = matches[1];
+        this.requestOptions.options.hostname = matches[1];
+        if (matches[2]) {
+          handlePort(matches[2], config);
+        }
+      } else {
+        throw `"${i}" does not look like a URL. Did you forget the http... prefix?`;
+      }
+    };
+
+    /**
+     * handleTenant
+     * set options.headers[x-okapi-tenant]
+     * @arg string
+     */
+    const handleTenant = (i, config) => {
+      config.tenant = i;
+      this.requestOptions.options.headers["x-okapi-tenant"] = i;
+    };
+
+    // I don't really want the hostname and tenant in here any more now that
+    // argument parsing has handler functions, but it's not worth refactoring.
+    const config = {
+      username: null,
+      password: null,
+      hostname: null,
+      tenant: null,
+    };
+
+    // argument handlers
+    const handlers = {
+      username: (i, config) => { config.username = i; },
+      password: (i, config) => { config.password = i; },
+      tenant:   handleTenant,
+      hostname: handleHostname,
+      port:     handlePort,
+      okapi:    handleOkapi,
+    };
+
+    // start at 2 because we get called like "node script.js --foo bar --bat baz"
+    // search for pairs of the form
+    //   --key value
+    // when a key matches a config-key, call its handlers function
+    for (let i = 2; i < args.length; i++) {
+      let key;
+      if (args[i].indexOf('--') === 0) {
+        key = args[i].substr(2);
+        if (key in handlers && i + 1 < args.length) {
+          handlers[key](args[++i], config);
+        }
+      }
+    }
+
+    // make sure all config values are non-empty
+    if (Object.values(config).filter(v => v).length == Object.keys(config).length) {
+      return config;
+    }
+
+    throw `A required argument was not present; missing one of: ${Object.keys(config).join(', ')}.`;
+  };
+
+
+  /**
+   *
+   */
+  constructor(argv)
+  {
+    // process CLI args; throws if we weren't called correctly
+    const config = this.processArgs(argv);
+
+    // login and cache the token
+    this.loginCreds = {
+      username: config.username,
+      password: config.password,
+    };
+  }
+
+  /** get request; return a promise */
+  get(path)
+  {
+    return this.request(path, null, 'GET');
+  }
+
+  /**
+   * retrieve all entries from a given endpoint in $limit-sized batches;
+   * return a promise containing all results in a single array.
+   */
+  getAll(path, name, batchSize)
+  {
+    return this.get(`${path}&limit=0`).then(res => {
+      const queries = [];
+      const max = res.json.totalRecords;
+      for (let i = 0; i < max; i+= batchSize) {
+        queries.push(`${path}&limit=${batchSize}&offset=${i}`);
+      }
+      let entries = [];
+      return this.eachPromise(queries, (r) => {
+        return this.get(r).then(res => {
+          entries = [...entries, ...res.json[name]];
+          return entries;
+        });
+      });
+    });
+  }
+
+  /** post request; return a promise */
+  post(path, body)
+  {
+    return this.request(path, body, 'POST');
+  }
+
+  /** put request; return a promise */
+  put(path, body)
+  {
+    return this.request(path, body, 'PUT');
+  }
+
+  /** delete request; return a promise */
+  delete(path)
+  {
+    return this.request(path, null, 'DELETE');
+  }
+
+  /**
+   * eachPromise
+   * iterate through an array of items IN SERIES, applying the given async
+   * function to each.
+   * @arg [] arr array of elements
+   * @arg function fn function to apply to each element
+   * @return promise
+   */
+  eachPromise(arr, fn)
+  {
+    if (!Array.isArray(arr)) return Promise.reject(new Error('Array not found'));
+    return arr.reduce((prev, cur) => (prev.then(() => fn(cur))), Promise.resolve());
+  };
+
+  /**
+   * login
+   * send a post request to bl-users/login with the --username and --password
+   * values provided to the constructor. pull the x-okapi-token out of the
+   * response header and store it in this.requestOptions; store the response-body
+   * in this.userInfo.
+   *
+   * return a promise
+   */
+  login()
+  {
+     return this.post('/bl-users/login', this.loginCreds).then(res => {
+       this.requestOptions.options.headers['x-okapi-token'] = res.headers['x-okapi-token'];
+       this.userInfo = res.json;
+     });
+  }
+};
+
+export default OkapiRequest;

--- a/okapi-request/package.json
+++ b/okapi-request/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "okapi-request",
+  "type": "module",
+  "version": "1.0.0",
+  "description": "A dependency-less Okapi request library for use in node-based scripts",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC"
+}


### PR DESCRIPTION
`index.js` node script performs the following actions:

1. check in all outstanding loans (this will clear patron blocks due to
   items aged to lost; it will also generate lots of fee/fines records)
2. transfer all outstanding fee/fine records (this will close all open fee/fines)
3. cancel all Page requests with request status Open- Not yet filled
4. anonymize all closed loans
5. delete all closed fee/fines

HTTP request handling is abstracted in `okapi-request`.

Refs [FOLIO-2904](https://issues.folio.org/browse/FOLIO-2904)