### PR TITLE
robustness tweaks in okapi-request libraries

### DIFF
--- a/clear-loans/DAO.js
+++ b/clear-loans/DAO.js
@@ -12,13 +12,13 @@ class DAO
    */
   getOpenLoans()
   {
-    return this.okapi.getAll('/circulation/loans?query=status.name=="Open"', 'loans', this.limit);
+    return this.okapi.getAll('/circulation/loans?query=status.name=="Open" sortby id', 'loans', this.limit);
   }
 
   /**
    * check in the given loan at the given service point
    */
-  checkin(loan, sp)
+  checkin(loan, sp, resolution)
   {
     if (loan.item.barcode) {
       const body = {
@@ -26,6 +26,10 @@ class DAO
         servicePointId: sp.id,
         checkInDate: new Date().toISOString(),
       };
+
+      if (resolution) {
+        body.claimedReturnedResolution = resolution;
+      }
 
       return this.okapi.post('/circulation/check-in-by-barcode', body).then(res => res.json);
     }
@@ -47,7 +51,7 @@ class DAO
    * retrieve all accounts by status, in $limit sized-batches; return a single array
    */
   getAccounts(status) {
-    return this.okapi.getAll(`/accounts?query=status.name=="${status}"`, 'accounts', this.limit);
+    return this.okapi.getAll(`/accounts?query=status.name=="${status}" sortby id`, 'accounts', this.limit);
   }
 
   /**
@@ -90,7 +94,7 @@ class DAO
    */
   getRequests(type, status)
   {
-    return this.okapi.get(`/request-storage/requests?query=requestType==${type} and status=="${status}"`, 'requests', this.limit);
+    return this.okapi.getAll(`/request-storage/requests?query=requestType==${type} and status=="${status}" sortby id`, 'requests', this.limit);
   }
 
   /**
@@ -117,7 +121,7 @@ class DAO
    */
   getNonAnonymizedClosedLoans()
   {
-    return this.okapi.get('/circulation/loans?query=status.name==Closed and userId=""', 'loans', this.limit);
+    return this.okapi.getAll('/circulation/loans?query=status.name==Closed and userId="" sortby id', 'loans', this.limit);
   }
 
   /**

--- a/okapi-request/lib/OkapiRequest.js
+++ b/okapi-request/lib/OkapiRequest.js
@@ -39,7 +39,7 @@ class OkapiRequest
       "headers": {
         "Content-type": "application/json",
         "cache-control": "no-cache",
-        "accept": "application/json"
+        "accept": "application/json, text/plain"
       },
     },
     "handler": undefined,


### PR DESCRIPTION
This script ran just fine against a small selection of sample data but
when given 10k+ real loans to work through, certain inadequacies became
apparent that are addressed herein.

### OkapiRequest
* change the `accept` header from `application/json` to
`application/json, text/plain` to accommodate certain `DELETE` requests
that require `text/plain`.

### DAO
* provide `sortby` clauses to `getAll` queries since the order is not
stable otherwise. IOW, `sortby` without an `orderby` clause is pretty
much worthless: it may contain dupes and it is not guaranteed to
actually retrieve all records. Ooooof.
* `checkin()` accepts an optional `resolution` argument that is required
for discharging items that are otherwise rejected as claimed-returned.
* correctly retrieve _all_ non-anonymized closed loans
* correctly retrieve _all_ requests

### clear-loans (index)
* report request failures and continue instead of dying.
* report the number of items in a list before iterating through it