### PR TITLE
Store permissionName as additional key for permission lookups

### DIFF
--- a/add-users/add-users.js
+++ b/add-users/add-users.js
@@ -341,6 +341,7 @@ const getPermissions = async () => {
   if (res.json.totalRecords) {
     const hash = {};
     res.json.permissions.forEach(p => {
+      hash[p.permissionName.toLowerCase()] = p.permissionName;
       try {
         if (p.displayName) {
           hash[p.displayName.toLowerCase()] = p.permissionName;


### PR DESCRIPTION
In order that users can be added with psets that have no displayName