### PR TITLE
FOLIO-3163: Update jenkins-slave-docker/Dockerfile.focal-java-11

### DIFF
--- a/jenkins-slave-docker/Dockerfile.focal-java-11
+++ b/jenkins-slave-docker/Dockerfile.focal-java-11
@@ -63,7 +63,7 @@ RUN apt-get -q update && \
 RUN npm install -g raml2html@3.0.1 && \
   npm install -g npm-snapshot
 
-ARG YARN_VERSION=1.22.4-1
+ARG YARN_VERSION=1.22.5-1
 RUN wget -O - https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
     sh -c 'echo "deb https://dl.yarnpkg.com/debian/ stable main" \
     >> /etc/apt/sources.list.d/yarn.list' && \
@@ -72,7 +72,7 @@ RUN wget -O - https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
     yarn global add @folio/stripes-cli --prefix /usr/local
 
 # Install Docker cli
-ARG DOCKER_VERSION=19.03.9
+ARG DOCKER_VERSION=20.10.6
 RUN wget -q --no-cookies \
     https://download.docker.com/linux/static/stable/x86_64/docker-${DOCKER_VERSION}.tgz \
     -O /tmp/docker.tgz && \
@@ -85,8 +85,8 @@ RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2
   unzip ./awscliv2.zip -d /tmp && /tmp/aws/install && \
   rm -rf /tmp/aws && rm ./awscliv2.zip
 
-# Ansible 2.7.5 (from pip)
-ARG ANSIBLE_VER=2.9.13
+# Ansible (from pip)
+ARG ANSIBLE_VER=2.9.21
 RUN pip3 install boto && \
     pip3 install boto3 && \
     pip3 install jmespath && \

--- a/jenkins-slave-docker/NEWS.md
+++ b/jenkins-slave-docker/NEWS.md
@@ -1,3 +1,30 @@
+## 2.8.2 2021-05-17
+
+* Update Ansible from 2.9.13 to 2.9.21 fixing security issues:
+  * https://access.redhat.com/security/cve/cve-2021-2022 - Mask default and fallback values for `no_log` module options
+  * https://access.redhat.com/security/cve/cve-2021-20191 - Various modules missing `no_log` on sensitive module arguments
+  * https://access.redhat.com/security/cve/cve-2021-20180 - `bitbucket_pipeline_variable` - hide user sensitive information which are marked as `secured` from logging into the console
+  * https://access.redhat.com/security/cve/cve-2021-20178 - `snmp_facts` - hide user sensitive information such as ``privkey`` and ``authkey`` from logging into the console
+  * https://access.redhat.com/security/cve/cve-2020-1753 - kubectl connection plugin - now redacts `kubectl_token` and `kubectl_password` in console log
+
+* Update Docker from 19.03.9 to 20.10.6 fixing
+  * CVE-2021-21285 Prevent an invalid image from crashing docker daemon https://github.com/moby/moby/security/advisories/GHSA-6fj5-m822-rqx8
+  * CVE-2021-21284 Lock down file permissions to prevent remapped root from accessing docker state https://github.com/moby/moby/security/advisories/GHSA-7452-xqpj-6rpc
+  * CVE-2019-14271 loading of nsswitch based config inside chroot under Glibc https://github.com/moby/moby/pull/39612
+  * CVE-2020-15257 Update bundled static binaries of containerd to v1.3.9 https://github.com/containerd/containerd/security/advisories/GHSA-36xw-fx78-c5r4
+
+* Update Yarn from 1.22.4 to 1.22.5, to the classic stable version: https://classic.yarnpkg.com/lang/en/
+
+* The re-build also updates many other tools, most notably Node:
+
+* Update Node from 12.20.1 to 12.22.1 fixing
+  * https://nodejs.org/en/blog/vulnerability/april-2021-security-releases/ OpenSSL - CA certificate check bypass with `X509_V_FLAG_X509_STRICT` (CVE-2021-3450)
+  * https://nodejs.org/en/blog/vulnerability/april-2021-security-releases/ OpenSSL - NULL pointer deref in signature_algorithms processing (CVE-2021-3449)
+  * https://nodejs.org/en/blog/vulnerability/april-2021-security-releases/ npm upgrade - Update y18n to fix Prototype-Pollution (CVE-2020-7774)
+  * https://nodejs.org/en/blog/vulnerability/february-2021-security-releases/ HTTP2 'unknownProtocol' cause Denial of Service by resource exhaustion (CVE-2021-22883)
+  * https://nodejs.org/en/blog/vulnerability/february-2021-security-releases/ DNS rebinding in --inspect (CVE-2021-22884)
+  * https://nodejs.org/en/blog/vulnerability/february-2021-security-releases/ OpenSSL - Integer overflow in CipherUpdate (CVE-2021-23840)
+
 ## 2.8.1 2021-04-19
 
 * Update api-doc FOLIO-2898


### PR DESCRIPTION
* Update Ansible from 2.9.13 to 2.9.21 fixing security issues:
  * https://access.redhat.com/security/cve/cve-2021-2022 - Mask default and fallback values for `no_log` module options
  * https://access.redhat.com/security/cve/cve-2021-20191 - Various modules missing `no_log` on sensitive module arguments
  * https://access.redhat.com/security/cve/cve-2021-20180 - `bitbucket_pipeline_variable` - hide user sensitive information which are marked as `secured` from logging into the console
  * https://access.redhat.com/security/cve/cve-2021-20178 - `snmp_facts` - hide user sensitive information such as ``privkey`` and ``authkey`` from logging into the console
  * https://access.redhat.com/security/cve/cve-2020-1753 - kubectl connection plugin - now redacts `kubectl_token` and `kubectl_password` in console log

* Update Docker from 19.03.9 to 20.10.6 fixing
  * CVE-2021-21285 Prevent an invalid image from crashing docker daemon https://github.com/moby/moby/security/advisories/GHSA-6fj5-m822-rqx8
  * CVE-2021-21284 Lock down file permissions to prevent remapped root from accessing docker state https://github.com/moby/moby/security/advisories/GHSA-7452-xqpj-6rpc
  * CVE-2019-14271 loading of nsswitch based config inside chroot under Glibc https://github.com/moby/moby/pull/39612
  * CVE-2020-15257 Update bundled static binaries of containerd to v1.3.9 https://github.com/containerd/containerd/security/advisories/GHSA-36xw-fx78-c5r4

* Update Yarn from 1.22.4 to 1.22.5, to the classic stable version: https://classic.yarnpkg.com/lang/en/

* The re-build also updates many other tools, most notably Node:

* Update Node from 12.20.1 to 12.22.1 fixing
  * https://nodejs.org/en/blog/vulnerability/april-2021-security-releases/ OpenSSL - CA certificate check bypass with `X509_V_FLAG_X509_STRICT` (CVE-2021-3450)
  * https://nodejs.org/en/blog/vulnerability/april-2021-security-releases/ OpenSSL - NULL pointer deref in signature_algorithms processing (CVE-2021-3449)
  * https://nodejs.org/en/blog/vulnerability/april-2021-security-releases/ npm upgrade - Update y18n to fix Prototype-Pollution (CVE-2020-7774)
  * https://nodejs.org/en/blog/vulnerability/february-2021-security-releases/ HTTP2 'unknownProtocol' cause Denial of Service by resource exhaustion (CVE-2021-22883)
  * https://nodejs.org/en/blog/vulnerability/february-2021-security-releases/ DNS rebinding in --inspect (CVE-2021-22884)
  * https://nodejs.org/en/blog/vulnerability/february-2021-security-releases/ OpenSSL - Integer overflow in CipherUpdate (CVE-2021-23840)