### PR TITLE
correctly handle single label

### DIFF
--- a/jspam/README.md
+++ b/jspam/README.md
@@ -39,6 +39,15 @@ Options:
   -h, --help         Show help                                         [boolean]
 ```
 
+Labels may be passed separately or as a comma-delimited string:
+```
+jspam ... --label foo --label bar
+```
+
+```
+jspam ... --label foo,bar
+```
+
 ## sample output
 
 ```

--- a/jspam/jspam.js
+++ b/jspam/jspam.js
@@ -225,7 +225,7 @@ class JSpam {
     }
 
     if (labels) {
-      body.fields.labels = labels;
+      body.fields.labels = Array.isArray(labels) ? labels : labels.split(',');
     }
 
     if (team) {


### PR DESCRIPTION
When multiple `--label value` flags are passed in, `label` is converted
to an array of strings, but when only one is passed in it remains a
plain string. The Jira API expects an array, hence, `label` must always
be converted to an array.

If it is a string, split it on commas, allowing usage like either
`--label foo --label bar` or `--label foo,bar` to have the same effect.