### PR TITLE
Deploy infrastructure locally using docker FOLIO-3195

### DIFF
--- a/infrastructure/local/README.md
+++ b/infrastructure/local/README.md
@@ -1,0 +1,35 @@
+## Purpose
+
+To allow developers to run the infrastructure needed to run FOLIO back end modules locally.
+
+## Infrastructure Included
+
+* PostgreSQL 10
+* Kafka
+
+## Prerequisites
+
+* [Docker Desktop](https://www.docker.com/products/docker-desktop)
+
+## Usage
+
+These commands are specific to later versions of Docker where compose is part of the main CLI
+
+### Starting the infrastructure containers
+
+Run `docker compose up -d`
+
+### Stopping the infrastructure containers
+
+Run `docker compose down`
+
+## Design
+
+### File Structure
+
+A single docker compose file chosen to make it easy to use with limited commands. 
+
+A trade off with this approach is that it does not provide the flexibility to only 
+run part of the infrastructure that a particular module uses. 
+
+This could be addressed by separating the file by part of the infrastructure e.g. PostgreSQL, Kafka  

--- a/infrastructure/local/docker-compose.yml
+++ b/infrastructure/local/docker-compose.yml
@@ -1,0 +1,39 @@
+version: "3"
+services:
+  postgres:
+    image: "postgres:10-alpine"
+    environment:
+      - POSTGRES_USER=folio
+      - POSTGRES_PASSWORD=folio
+      - POSTGRES_DB=folio
+    ports:
+      - "5432:5432"
+  zookeeper:
+    image: wurstmeister/zookeeper
+    container_name: zookeeper
+    restart: always
+    ports:
+      - "2181:2181"
+  kafka:
+    image: wurstmeister/kafka
+    container_name: kafka
+    restart: always
+    ports:
+      - "9092:9092"
+      - "29092:29092"
+    environment:
+      KAFKA_LISTENERS: INTERNAL://:9092,LOCAL://:29092
+      KAFKA_ADVERTISED_LISTENERS: INTERNAL://:9092,LOCAL://:29092
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: LOCAL:PLAINTEXT,INTERNAL:PLAINTEXT
+      KAFKA_INTER_BROKER_LISTENER_NAME: INTERNAL
+      KAFKA_AUTO_CREATE_TOPICS_ENABLE: "true"
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_BROKER_ID: 1
+      KAFKA_LOG_RETENTION_BYTES: -1
+      KAFKA_LOG_RETENTION_HOURS: -1
+    depends_on:
+      - zookeeper
+
+networks: 
+  default: 
+    name: folio_network


### PR DESCRIPTION
Whilst trying to test the upgrade process for mod-inventory-storage, I decided to experiment with using Docker compose to repeatable set up the infrastructure needed locally and to deploy an instance of the module.

I thought the infrastructure part of this might be useful for others. folio-tools seems like the appropriate repository for this. Please let me know if this is not the appropriate place.