### PR TITLE
FOLIO-3248 clear loans fast like rabbit

### DIFF
--- a/clear-loans/README.md
+++ b/clear-loans/README.md
@@ -14,9 +14,19 @@
 ```
 node $0 --username <u> --password <p> --tenant <t> --hostname <h> --port <p>
 node $0 --username <u> --password <p> --tenant <t> --okapi <http...>
+node $0 ... --pageSize <n> --streams <n>
+
 ```
 where username, password, and tenant are credentials for signing into
 the okapi instance available at hostname. Given a hostname via `--hostname`,
 handle all requests over https. Given a URL via `--okapi`, parse the value
 and determine whether to handle requests with http or https based on the
 protocol.
+
+Given `--pageSize <n>` where `n` is an integer, request `n` entries at a time,
+in series. Default: 100.
+
+Given `--streams <n>` where `n` is an integer, process requests in `n` parallel
+streams. e.g. if there are 1000 rows in a result set, `--streams 10` would
+create 10 parallel requests for 100 entries (the default page-size) instead
+of running those requests in series.

--- a/clear-loans/index.js
+++ b/clear-loans/index.js
@@ -211,8 +211,35 @@ class ClearLoans
     });
   }
 
+  /**
+   * replace console function with one that includes a timestamp prefix
+   * @param {string} fx name of a console function, e.g. log, error
+   */
+  consoleReplace(fx) {
+    if (console[fx]) {
+      const originalLog = console[fx];
+      console[fx] = (...rest) => {
+        const av = Array.from(rest);
+        const stamp = new Date().toISOString();
+        if (av[0]) {
+          if (typeof av[0] === 'string') {
+            av[0] = `${stamp} ${av[0]}`;
+          } else {
+            av.unshift(stamp);
+          }
+        }
+
+        originalLog.apply(null, av);
+      }
+    }
+  }
+
+
   main()
   {
+    this.consoleReplace('log')
+    this.consoleReplace('error')
+
     try {
       this.okapi = new OkapiRequest(process.argv);
       this.dao = new DAO(this.okapi);

--- a/okapi-request/README.md
+++ b/okapi-request/README.md
@@ -6,7 +6,7 @@ The `OkapiRequest` class provides the following functions that return Promises:
 
 * `login()`
 * `get(path)`
-* `getAll(path, object-name, batch-size)`
+* `getAll(path, object-name, page-size)`
 * `post(path, {})`
 * `put(path, {})`
 * `delete(path)`
@@ -16,7 +16,16 @@ The constructor takes an array and should be called like
 const o = new OkapiRequest(['--username', 'some-u', '--password', 'some-pw', ...])
 ```
 Where the `--` keys include the following: `username`, `password`, `tenant`,
-and either (`hostname` and `port`) or (`okapi`).
+and either (`hostname` and `port`) or (`okapi`). Optional keys are `pageSize`
+and `streams`.
+
+If `process.argv` contains `--pageSize N`, it will override the given page-size.
+
+If `process.argv` contains `--streams N`, `getAll` will execute N queries in
+parallel. Without `--streams`, `getAll` always executes in series. e.g. if
+there are 100 rows, `--pageSize 25` will execute 4 queries in series whereas
+`--pageSize 25 --streams 4` will execute 2 parallel streams, each with 2
+queries running in series.
 
 ### usage
 

--- a/okapi-request/lib/OkapiRequest.js
+++ b/okapi-request/lib/OkapiRequest.js
@@ -15,6 +15,10 @@ import http from 'http';
  * or
  *     --hostname [hostname]
  *     --port [port]
+ * and optionally
+ *     --pageSize [item-count to retrieve in a single page]
+ *     --streams [page-count to retrieve in parallel]
+ *
  *
  * Use it like this:
  *     const okapi = new OkapiRequest(process.argv);
@@ -166,6 +170,30 @@ class OkapiRequest
       this.requestOptions.options.headers["x-okapi-tenant"] = i;
     };
 
+    /**
+     * handlePageSize; basically atoi
+     */
+    const handlePageSize = (i, config) => {
+      const v = Number.parseInt(i, 10);
+      if (! isNaN(v)) {
+        config.pageSize = v;
+      } else {
+        throw `The pageSize value "${i}" is not a valid number.`;
+      }
+    };
+
+    /**
+     * handleStreams; basically atoi
+     */
+    const handleStreams = (i, config) => {
+      const v = Number.parseInt(i, 10);
+      if (! isNaN(v)) {
+        config.streams = v;
+      } else {
+        throw `The streams value "${i}" is not a valid number.`;
+      }
+    };
+
     // I don't really want the hostname and tenant in here any more now that
     // argument parsing has handler functions, but it's not worth refactoring.
     const config = {
@@ -183,6 +211,8 @@ class OkapiRequest
       hostname: handleHostname,
       port:     handlePort,
       okapi:    handleOkapi,
+      streams:  handleStreams,
+      pageSize: handlePageSize,
     };
 
     // start at 2 because we get called like "node script.js --foo bar --bat baz"
@@ -221,6 +251,12 @@ class OkapiRequest
       username: config.username,
       password: config.password,
     };
+
+    // how many records to retrieve at once
+    this.pageSize = config.pageSize;
+
+    // given an array of promises, how many streams to execute in parallel
+    this.streams = config.streams;
   }
 
   /** get request; return a promise */
@@ -235,15 +271,24 @@ class OkapiRequest
    */
   getAll(path, name, batchSize)
   {
+    const pageSize = this.pageSize ?? batchSize;
+    if (pageSize === 0) {
+      throw "You must specify a page-size";
+    }
+
     return this.get(`${path}&limit=0`).then(res => {
       const queries = [];
       const max = res.json.totalRecords;
-      for (let i = 0; i < max; i+= batchSize) {
-        queries.push(`${path}&limit=${batchSize}&offset=${i}`);
+      console.log(`found ${max} ${name} records`)
+      for (let i = 0; i < max; i+= pageSize) {
+        queries.push(`${path}&limit=${pageSize}&offset=${i}`);
       }
       let entries = [];
+      // console.log(`that'll be ${queries.length} batches of ${pageSize}`)
+      let batch = 0;
       return this.eachPromise(queries, (r) => {
         return this.get(r).then(res => {
+          // console.log(`retrieved batch ${++batch}`)
           entries = [...entries, ...res.json[name]];
           return entries;
         });
@@ -272,7 +317,9 @@ class OkapiRequest
   /**
    * eachPromise
    * iterate through an array of items IN SERIES, applying the given async
-   * function to each.
+   * function to each element. If this.streams is non-zero, partition the
+   * array into streams and handling the streams in parallel but each stream
+   * in series.
    * @arg [] arr array of elements
    * @arg function fn function to apply to each element
    * @return promise
@@ -280,7 +327,47 @@ class OkapiRequest
   eachPromise(arr, fn)
   {
     if (!Array.isArray(arr)) return Promise.reject(new Error('Array not found'));
-    return arr.reduce((prev, cur) => (prev.then(() => fn(cur))), Promise.resolve());
+
+    /**
+     * eachPromiseSeries
+     * Split an array of Promises into N chunks to be handled in parallel,
+     * the items in each chunk being handled in series. e.g given 100 elements
+     * and a chunk-size of 4, create 4 parallel streams that handle 25 promises
+     * in series, applying the given async function to each.
+     * @arg [] arr array of elements
+     * @arg function fn function to apply to each element
+     * @return promise
+     */
+    const eachPromiseSeries = (arr, fn) => {
+      // console.log('SERIES')
+      return arr.reduce((prev, cur) => (prev.then(() => fn(cur))), Promise.resolve());
+    };
+
+    /**
+     * eachPromiseParallel
+     * Split an array of Promises into N partitions to be handled in parallel,
+     * the items in each partition being handled in series. e.g given 100 elements
+     * and a partition-size of 4, create 4 parallel streams that handle 25 promises
+     * in series, applying the given async function to each.
+     * @arg [] arr array of elements
+     * @arg function fn function to apply to each element
+     * @arg int size number of partitions to handle in parallel
+     * @return promise
+     */
+    const eachPromiseParallel = (arr, fn, partitionSize) => {
+      // console.log('PARALLEL')
+      const size = Math.ceil(arr.length / partitionSize);
+      const streams = [];
+      for (let i = 0; i < arr.length; i += size) {
+        streams.push(eachPromiseSeries(arr.slice(i, i + size), fn));
+      }
+
+      return Promise.all(streams).then(values => {
+        return [].concat(...values);
+      });
+    };
+
+    return this.streams ? eachPromiseParallel(arr, fn, this.streams) : eachPromiseSeries(arr, fn);
   };
 
   /**


### PR DESCRIPTION
Refactor `okapi-request::getAll` to handle the optional CLI parameters
`--pageSize` (how many items to retrieve in a single request) and
`--streams` (how many requests to run in parallel) to allow for faster
execution with large result sets.

`getAll()` was originally written specifically to handle requests in
series because uncontrolled parallelization in the browser was
overwhelming backend APIs. Here, where scripts are being run in strictly
controlled circumstances by sys-admins who know exactly what they are
doing and exactly what the repercussions will be if they run a jillion
parallel requests, we want to grant them the power to override those
conservative default values.

Also, prefix `console.log` and `console.error` output with a timestamp
to make debugging a wee bit easier.

Refs [FOLIO-3248](https://issues.folio.org/browse/FOLIO-3248)