### PR TITLE
handle current project-responsibilty-matrix format

### DIFF
--- a/jspam/jspam.js
+++ b/jspam/jspam.js
@@ -85,7 +85,13 @@ class JSpam {
    * getMatrix
    * retrieve and parse the team-project responsibility matrix from the given URL.
    * transpose it to an object keyed by the project's github name.
-   * @param {*} matrixUrl
+   *
+   * This is such an unholy mess. It would be _really_ nice to maintain the matrix
+   * in machine-readable format and driving the wiki page from that, rather than
+   * vice-versa and having to tweak the parser every time somebody changes the
+   * HTML markup.
+   *
+   * @param {string} matrixUrl
    */
   async getMatrix(matrixUrl)
   {
@@ -94,20 +100,35 @@ class JSpam {
     // const matrix = fs.readFileSync('Team+vs+module+responsibility+matrix', { encoding: 'UTF-8' });
 
     const userFromTd = (td) => {
-      return td.querySelector ? td.querySelector('a')?.getAttribute('data-username') : null;
+      return td.querySelector ? td.querySelector('a')?.getAttribute('data-username')?.trim() : null;
     }
 
-    const ths = parse(matrix).querySelectorAll('.confluenceTable tbody th');
+    const teams = Array.from(parse(matrix).querySelectorAll('.confluenceTable tbody tr'));
 
-    const teams = parse(matrix).querySelectorAll('.confluenceTable tbody tr');
+    // pluck the first row, pretending it's a <thead> effectively,
+    // so it can be used as a template for parsing other rows
+    // which may have missing team or product-owner cells because
+    // a td above spans multiple rows.
+    const ths = Array.from(teams.shift().querySelectorAll('td'));
+
     let pteam = { team: '', po: '', tl: '', github: '', jira: '' };
     teams.forEach((tr, i) => {
       const tds = Array.from(tr.querySelectorAll('td'));
-      if (tds.length === ths.length - 1) {
-        tds.unshift({ text: '' });
-      }
-      else if (tds.length === ths.length - 2) {
-        tds.unshift({ text: '' });
+
+      // jigger tds so it always resembles ths, i.e. so there is always a 1::1
+      // correspondence between the th and the td. if we have a table like this:
+      //
+      // | TEAM | PO | TL | junk | REPO | JIRA |
+      // | Aaaa | Aa | Aa | junk | Aaaa | Aaaa |
+      // |      | Bb | Bb | junk | Bbbb | Bbbb |
+      // | Cccc | Cc | Cc | junk | Cccc | Cccc |
+      // |      |    | Dd | junk | Dddd | Dddd |
+      //
+      // then the A-row and C-row have the same number of cols, but the B-row
+      // is short by one and the D-row is short by two because of the cells
+      // above that span multiple rows.
+
+      while (tds.length < ths.length) {
         tds.unshift({ text: '' });
       }
 
@@ -115,11 +136,11 @@ class JSpam {
       // I don't really know what kind of data structure `tds` is.
       // iterating with (td, j) works just fine, but trying to access tds[j] fails.
       tds.forEach((td, j) => {
-        if (j == 0) team.team = td.text || pteam.team;
+        if (j == 0) team.team = td.text.trim() || pteam.team;
         if (j == 1) team.po = userFromTd(td) || pteam.po;
         if (j == 2) team.tl = userFromTd(td) || pteam.tl;
-        if (j == 4) team.github = td.text;
-        if (j == 5) team.jira = td.text;
+        if (j == 4) team.github = td.text.trim();
+        if (j == 5) team.jira = td.text.trim();
       });
 
       if (team.github) {
@@ -371,7 +392,6 @@ class JSpam {
       this.relatesLink = this.linkTypes.data.issueLinkTypes.find(link => link.name === 'Relates');
 
       this.matrix = await this.getMatrix('https://wiki.folio.org/display/REL/Team+vs+module+responsibility+matrix');
-
       // get ticket from Jira
       let link;
       if (this.argv.link) {
@@ -403,9 +423,8 @@ class JSpam {
         // map the array of projects into a hash keyed by name, e.g. ui-some-app
         const pmap = {};
         projects.data.forEach(p => { pmap[p.name] = p; });
-
         this.eachPromise(deps, d => {
-          if (pmap[d]) {
+          if (pmap[d] && this.matrix[d]) {
             this.teamForName(this.matrix[d].team)
             .then(team => {
               // only assign the team if we received --team

--- a/parse-matrix/README.md
+++ b/parse-matrix/README.md
@@ -5,6 +5,7 @@
 Read the wiki's team-module-responsibility matrix and output it as a
 JSON object keyed by GitHub repository name:
 ```
+{
   "okapi": {
     "team": "Core Platform",
     "po": "jakub",
@@ -12,6 +13,8 @@ JSON object keyed by GitHub repository name:
     "github": "okapi",
     "jira": "OKAPI"
   },
+  ...
+}
 ```
 * `team`: Jira team responsible for the module
 * `po`: Wiki/Jira username of the product owner

--- a/parse-matrix/parse-matrix.js
+++ b/parse-matrix/parse-matrix.js
@@ -21,17 +21,32 @@ class ParseMatrix {
       return td.querySelector ? td.querySelector('a')?.getAttribute('data-username') : null;
     }
 
-    const ths = parse(matrix).querySelectorAll('.confluenceTable tbody th');
-
     const teams = parse(matrix).querySelectorAll('.confluenceTable tbody tr');
+
+    // pluck the first row, pretending it's a <thead> effectively,
+    // so it can be used as a template for parsing other rows
+    // which may have missing team or product-owner cells because
+    // a td above spans multiple rows.
+    const ths = Array.from(teams.shift().querySelectorAll('td'));
+
     let pteam = { team: '', po: '', tl: '', github: '', jira: '' };
     teams.forEach((tr, i) => {
       const tds = Array.from(tr.querySelectorAll('td'));
-      if (tds.length === ths.length - 1) {
-        tds.unshift({ text: '' });
-      }
-      else if (tds.length === ths.length - 2) {
-        tds.unshift({ text: '' });
+
+      // jigger tds so it always resembles ths, i.e. so there is always a 1::1
+      // correspondence between the th and the td. if we have a table like this:
+      //
+      // | TEAM | PO | TL | junk | REPO | JIRA |
+      // | Aaaa | Aa | Aa | junk | Aaaa | Aaaa |
+      // |      | Bb | Bb | junk | Bbbb | Bbbb |
+      // | Cccc | Cc | Cc | junk | Cccc | Cccc |
+      // |      |    | Dd | junk | Dddd | Dddd |
+      //
+      // then the A-row and C-row have the same number of cols, but the B-row
+      // is short by one and the D-row is short by two because of the cells
+      // above that span multiple rows.
+
+      while (tds.length < ths.length) {
         tds.unshift({ text: '' });
       }
 


### PR DESCRIPTION
Recent updates to the project responsibility matrix HTML markup broke
the parser (header-columns are no longer contained in `<th>`) so we need
to get clever to figure out how to map between the headers specified in
the first row and the data in the remaining rows.