### PR TITLE
FOLIO-3366 folio-java-docker alpine 3.15.0

### DIFF
--- a/folio-java-docker/openjdk11/Dockerfile
+++ b/folio-java-docker/openjdk11/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:latest
+FROM alpine:3.15.0
 
 USER root
 

--- a/folio-java-docker/openjdk11/NEWS.md
+++ b/folio-java-docker/openjdk11/NEWS.md
@@ -1,3 +1,7 @@
+## 1.2.0 2021-12-23
+
+* Upgraded to Alpine 3.15.0 [FOLIO-3366](https://issues.folio.org/browse/FOLIO-3366)
+
 ## 1.1.0 2021-08-20
 
 * Alpine 3.14


### PR DESCRIPTION
Tag image as 1.2.0

[FOLIO-3366](https://issues.folio.org/browse/FOLIO-3366)
