### PR TITLE
FOLIO-3405: OpenJDK Adoptium (Eclipse Temurin) for alpine-jre-openjdk11

### DIFF
--- a/folio-java-docker/openjdk11/Dockerfile
+++ b/folio-java-docker/openjdk11/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.15.0
+FROM eclipse-temurin:11-jre-alpine
 
 USER root
 
@@ -7,13 +7,6 @@ RUN mkdir -p /usr/verticles
 # JAVA_APP_DIR is used by run-java.sh for finding the binaries
 ENV JAVA_APP_DIR=/usr/verticles \
     JAVA_MAJOR_VERSION=11
-
-# /dev/urandom is used as random source, which is perfectly safe
-# according to http://www.2uo.de/myths-about-urandom/
-RUN apk add --no-cache \
-    curl \
-    openjdk11-jre-headless \
- && echo "securerandom.source=file:/dev/urandom" >> /usr/lib/jvm/default-jvm/jre/lib/security/java.security
 
 # Add run script as JAVA_APP_DIR/run-java.sh and make it executable
 COPY run-java.sh ${JAVA_APP_DIR}/

--- a/folio-java-docker/openjdk11/Dockerfile
+++ b/folio-java-docker/openjdk11/Dockerfile
@@ -8,6 +8,9 @@ RUN mkdir -p /usr/verticles
 ENV JAVA_APP_DIR=/usr/verticles \
     JAVA_MAJOR_VERSION=11
 
+RUN apk add --no-cache \
+    libc6-compat     # https://issues.folio.org/browse/FOLIO-3406 for OpenSSL
+
 # Add run script as JAVA_APP_DIR/run-java.sh and make it executable
 COPY run-java.sh ${JAVA_APP_DIR}/
 RUN chmod 755 ${JAVA_APP_DIR}/run-java.sh

--- a/folio-java-docker/openjdk11/Dockerfile
+++ b/folio-java-docker/openjdk11/Dockerfile
@@ -9,6 +9,7 @@ ENV JAVA_APP_DIR=/usr/verticles \
     JAVA_MAJOR_VERSION=11
 
 RUN apk add --no-cache \
+    curl \
     libc6-compat     # https://issues.folio.org/browse/FOLIO-3406 for OpenSSL
 
 # Add run script as JAVA_APP_DIR/run-java.sh and make it executable

--- a/folio-java-docker/openjdk11/NEWS.md
+++ b/folio-java-docker/openjdk11/NEWS.md
@@ -1,3 +1,7 @@
+## 1.3.0 2022-02
+
+* Switched to OpenJDK Adoptium (Eclipse Temurin) [FOLIO-3405](https://issues.folio.org/browse/FOLIO-3405)
+
 ## 1.2.0 2021-12-23
 
 * Upgraded to Alpine 3.15.0 [FOLIO-3366](https://issues.folio.org/browse/FOLIO-3366)

--- a/folio-java-docker/openjdk11/run-java.sh
+++ b/folio-java-docker/openjdk11/run-java.sh
@@ -201,7 +201,7 @@ init_java_major_version() {
         else
             full_version=$(java -version 2>&1 | head -1 | sed -e 's/.*\"\([0-9.]\{1,\}\).*/\1/')
         fi
-        export JAVA_MAJOR_VERSION=$(echo $full_version | sed -e 's/\(1\.\)\{0,1\}\([0-9]\{1,\}\).*/\2/')
+        export JAVA_MAJOR_VERSION=$(echo $full_version | sed -e 's/[^0-9]*\(1\.\)\{0,1\}\([0-9]\{1,\}\).*/\2/')
     fi
 }
 


### PR DESCRIPTION
To reduce the folioci/alpine-jre-openjdk11 container size from 174 MB to 134 MB switch
from https://github.com/openjdk/jdk11u to OpenJDK Adoptium (Eclipse Temurin)
https://github.com/adoptium/containers = https://adoptium.net/ = https://hub.docker.com/_/eclipse-temurin

Setting securerandom.source=file:/dev/urandom is no longer needed because
this is the default for alpine:3.15.0.

The change in run-java.sh is copied from
https://github.com/fabric8io-images/java/blob/master/images/alpine/openjdk11/jre/run-java.sh

OpenSSL requires libc6-compat in Alpine:
https://issues.folio.org/browse/FOLIO-3406