### PR TITLE
FOLIO-3420: Upgrade expat, libuuid in python:alpine (CVE-2022-23852)

### DIFF
--- a/kubernetes-utilities/ci-cleanup/module-cleanup/Dockerfile
+++ b/kubernetes-utilities/ci-cleanup/module-cleanup/Dockerfile
@@ -1,5 +1,9 @@
 FROM python:3-alpine
 
+# Upgrade expat fixing https://nvd.nist.gov/vuln/detail/CVE-2022-23852 , https://nvd.nist.gov/vuln/detail/CVE-2022-23990
+# Upgrade libuuid fixing https://nvd.nist.gov/vuln/detail/CVE-2021-3995 , https://nvd.nist.gov/vuln/detail/CVE-2021-3996 , https://nvd.nist.gov/vuln/detail/CVE-2022-0563
+RUN apk upgrade --no-cache
+
 COPY ./requirements.txt requirements.txt
 
 # install python deps

--- a/kubernetes-utilities/ci-cleanup/tenant-cleanup/Dockerfile
+++ b/kubernetes-utilities/ci-cleanup/tenant-cleanup/Dockerfile
@@ -1,5 +1,9 @@
 FROM python:3-alpine
 
+# Upgrade expat fixing https://nvd.nist.gov/vuln/detail/CVE-2022-23852 , https://nvd.nist.gov/vuln/detail/CVE-2022-23990
+# Upgrade libuuid fixing https://nvd.nist.gov/vuln/detail/CVE-2021-3995 , https://nvd.nist.gov/vuln/detail/CVE-2021-3996 , https://nvd.nist.gov/vuln/detail/CVE-2022-0563
+RUN apk upgrade --no-cache
+
 ENV CLEANUP_OKAPI="http://okapi:9130"
 ENV CLEANUP_ORGANIZATION="folio-org"
 ENV CLEANUP_GH_TOKEN=""

--- a/kubernetes-utilities/folio-ansible-runner/Dockerfile
+++ b/kubernetes-utilities/folio-ansible-runner/Dockerfile
@@ -16,8 +16,12 @@ ENV KUBERNETES_TOKEN=''
 ENV PG_ADMIN_USER=''
 ENV PG_ADMIN_PASS=''
 
+# Upgrade expat fixing https://nvd.nist.gov/vuln/detail/CVE-2022-23852 , https://nvd.nist.gov/vuln/detail/CVE-2022-23990
+# Upgrade libuuid fixing https://nvd.nist.gov/vuln/detail/CVE-2021-3995 , https://nvd.nist.gov/vuln/detail/CVE-2021-3996 , https://nvd.nist.gov/vuln/detail/CVE-2022-0563
 # add dependencies
-RUN apk --update --no-cache add \
+RUN apk update && \
+  apk upgrade && \
+  apk add \
     gcc \
     bash \
     curl \
@@ -27,7 +31,8 @@ RUN apk --update --no-cache add \
     make \
     openssl-dev \
     postgresql-client \
-    postgresql-dev
+    postgresql-dev && \
+  rm -rf /var/cache/apk/*
 
 # install python deps
 RUN pip3 install --upgrade pip

--- a/kubernetes-utilities/md2kubeyaml/Dockerfile
+++ b/kubernetes-utilities/md2kubeyaml/Dockerfile
@@ -1,5 +1,9 @@
 FROM python:3-alpine
 
+# Upgrade expat fixing https://nvd.nist.gov/vuln/detail/CVE-2022-23852 , https://nvd.nist.gov/vuln/detail/CVE-2022-23990
+# Upgrade libuuid fixing https://nvd.nist.gov/vuln/detail/CVE-2021-3995 , https://nvd.nist.gov/vuln/detail/CVE-2021-3996 , https://nvd.nist.gov/vuln/detail/CVE-2022-0563
+RUN apk upgrade --no-cache
+
 # install python deps
 RUN pip3 install --upgrade pip
 RUN pip3 install argparse \

--- a/vufind-indexer/Dockerfile
+++ b/vufind-indexer/Dockerfile
@@ -1,5 +1,9 @@
 FROM python:3-alpine
 
+# Upgrade expat fixing https://nvd.nist.gov/vuln/detail/CVE-2022-23852 , https://nvd.nist.gov/vuln/detail/CVE-2022-23990
+# Upgrade libuuid fixing https://nvd.nist.gov/vuln/detail/CVE-2021-3995 , https://nvd.nist.gov/vuln/detail/CVE-2021-3996 , https://nvd.nist.gov/vuln/detail/CVE-2022-0563
+RUN apk upgrade --no-cache
+
 COPY ./requirements.txt requirements.txt
 
 # install python deps


### PR DESCRIPTION
The Docker containers based on the python:alpine image should upgrade these packages:

Upgrade expat from 2.4.3-r0 to 2.4.4-r0 fixing integer overflows:

* https://nvd.nist.gov/vuln/detail/CVE-2022-23852
* https://nvd.nist.gov/vuln/detail/CVE-2022-23990

Upgrade libuuid from 2.37.2-r1 to 2.37.4-r0 fixing util-linux:

* https://nvd.nist.gov/vuln/detail/CVE-2021-3995 = https://github.com/util-linux/util-linux/commit/f3db9bd609494099f0c1b95231c5dfe383346929
* https://nvd.nist.gov/vuln/detail/CVE-2021-3996 = https://github.com/util-linux/util-linux/commit/018a10907fa9885093f6d87401556932c2d8bd2b
* https://nvd.nist.gov/vuln/detail/CVE-2022-0563 = https://github.com/util-linux/util-linux/commit/39a81981ac4b8a1f521db550afc117ccab9548cb