### PR TITLE
FOLIO-3480: Downgrade zlib in jre container fixing ZipException

### DIFF
--- a/folio-java-docker/openjdk11/Dockerfile
+++ b/folio-java-docker/openjdk11/Dockerfile
@@ -8,9 +8,14 @@ RUN mkdir -p /usr/verticles
 ENV JAVA_APP_DIR=/usr/verticles \
     JAVA_MAJOR_VERSION=11
 
-RUN apk add --no-cache \
+# get zlib=1.2.11-r3 from v3.11
+RUN echo 'https://dl-cdn.alpinelinux.org/alpine/v3.11/main' >> /etc/apk/repositories \
+ && apk add --no-cache \
     curl \
-    libc6-compat     # https://issues.folio.org/browse/FOLIO-3406 for OpenSSL
+    # https://issues.folio.org/browse/FOLIO-3406 libc6-compat for OpenSSL
+    libc6-compat \
+    # https://issues.folio.org/browse/FOLIO-3480 downgrade zlib until 1.2.13 is available
+    zlib=1.2.11-r3
 
 # Add run script as JAVA_APP_DIR/run-java.sh and make it executable
 COPY run-java.sh ${JAVA_APP_DIR}/


### PR DESCRIPTION
Alpine has updated zlib to v1.2.12 that ships with this regression:
When running FOLIO containers in Windows Vagrant box Kafka
messages cause "ZipException: Corrupt GZIP trailer":
https://issues.folio.org/browse/FOLIO-3480
https://github.com/madler/zlib/issues/613

zlib has been fixed on develop branch:
https://github.com/madler/zlib/commit/ec3df00224d4b396e2ac6586ab5d25f673caa4c2

The fix hasn't been released yet.

Until zlib v1.2.13 is available downgrade zlib to the previous
version 1.2.11-r3 that works.