### PR TITLE
FOLIO-3487: zlib 1.2.12-r1 fixing ZipException

### DIFF
--- a/folio-java-docker/openjdk11/Dockerfile
+++ b/folio-java-docker/openjdk11/Dockerfile
@@ -8,10 +8,12 @@ RUN mkdir -p /usr/verticles
 ENV JAVA_APP_DIR=/usr/verticles \
     JAVA_MAJOR_VERSION=11
 
-RUN apk add --no-cache \
-    curl \
-    # https://issues.folio.org/browse/FOLIO-3406 libc6-compat for OpenSSL
-    libc6-compat
+RUN apk upgrade \
+ && apk add \
+      curl \
+      # https://issues.folio.org/browse/FOLIO-3406 libc6-compat for OpenSSL
+      libc6-compat \
+ && rm -rf /var/cache/apk/*
 
 # Add run script as JAVA_APP_DIR/run-java.sh and make it executable
 COPY run-java.sh ${JAVA_APP_DIR}/


### PR DESCRIPTION
The stable Alpine branch 3.15 finally got zlib 1.2.12-r1 with the fix:

https://gitlab.alpinelinux.org/alpine/aports/-/merge_requests/33688

However, as eclipse-temurin:11-jre-alpine hasn't been upgraded
to the latest zlib version it still contains the buggy
zlib 1.2.12-r0.

Therefore we need to manually run `apk upgrade`.

Testing the Dockerfile after applying this pull request by running
```
docker build -t x .
docker run --rm --entrypoint '/bin/sh' x -c 'apk list zlib'
```
yields
```
zlib-1.2.12-r1 x86_64 {zlib} (Zlib) [installed]
```
with the expected result.