### PR TITLE
FOLIO-3494 jenkins-slave-docker: java-17 with OpenJDK 17 and NodeJS v16

### DIFF
--- a/jenkins-slave-docker/Dockerfile.jammy-java-17
+++ b/jenkins-slave-docker/Dockerfile.jammy-java-17
@@ -1,4 +1,4 @@
-FROM ubuntu:focal
+FROM ubuntu:jammy
 
 # setup SSH server
 RUN apt-get update \
@@ -30,7 +30,7 @@ ENV LANGUAGE en_US:en
 ENV LC_ALL en_US.UTF-8
 
 ## Install Nodejs
-ARG NODEJS_VERSION=14
+ARG NODEJS_VERSION=16
 RUN curl -sL https://deb.nodesource.com/setup_${NODEJS_VERSION}.x | bash -
 
 # Install Postgres repo
@@ -50,7 +50,7 @@ RUN wget -q --no-cookies -O - \
 RUN apt-get -q update && \
     DEBIAN_FRONTEND="noninteractive" apt-get -q install -y \
     -o Dpkg::Options::="--force-confnew"  --no-install-recommends \
-    openjdk-11-jdk build-essential debhelper lintian fakeroot devscripts jq maven python3 \
+    openjdk-17-jdk build-essential debhelper lintian fakeroot devscripts jq maven python3 \
     python3-pip python3-setuptools python3-wheel python3-yaml python3-requests python3-sh nodejs \
     postgresql-client-${POSTGRES_VERSION} xvfb libgtk2.0-0 libxtst6 libxss1 libgconf-2-4 libnss3 \
     libnspr4 libasound2 firefox google-chrome-stable libaio1 zip python-is-python3 libyaz5 && \
@@ -68,7 +68,7 @@ ARG YARN_VERSION=1.22.18-1
 RUN wget -O - https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
     sh -c 'echo "deb https://dl.yarnpkg.com/debian/ stable main" \
     >> /etc/apt/sources.list.d/yarn.list' && \
-    apt-get -q update && apt-get install -y yarn=${YARN_VERSION} 
+    apt-get -q update && apt-get install -y yarn=${YARN_VERSION}
 
 # Install Docker cli
 ARG DOCKER_VERSION=20.10.14

--- a/jenkins-slave-docker/Dockerfile.jammy-java-17
+++ b/jenkins-slave-docker/Dockerfile.jammy-java-17
@@ -1,0 +1,170 @@
+FROM ubuntu:focal
+
+# setup SSH server
+RUN apt-get update \
+    && apt-get install --no-install-recommends -y openssh-server \
+    && apt-get clean
+RUN sed -i 's/#PermitRootLogin.*/PermitRootLogin no/' /etc/ssh/sshd_config && \
+    sed -i 's/#RSAAuthentication.*/RSAAuthentication yes/' /etc/ssh/sshd_config && \
+    sed -i 's/#PasswordAuthentication.*/PasswordAuthentication no/' /etc/ssh/sshd_config && \
+    sed -i 's/#SyslogFacility.*/SyslogFacility AUTH/' /etc/ssh/sshd_config && \
+    sed -i 's/#LogLevel.*/LogLevel INFO/' /etc/ssh/sshd_config && \
+    sed -i 's/session    required     pam_loginuid.so/session    optional     pam_loginuid.so/g' /etc/pam.d/sshd && \
+    mkdir /var/run/sshd
+
+#  Add utility packages to image
+RUN DEBIAN_FRONTEND="noninteractive" apt-get -q install -y \
+    -o Dpkg::Options::="--force-confnew"  --no-install-recommends \
+    apt-utils ca-certificates locales gnupg2 tzdata vim-tiny curl \
+    cmake g++ libcurl4-openssl-dev libpq-dev postgresql-server-dev-all \
+    rapidjson-dev unixodbc unixodbc-dev wget unzip lsb-release sudo git && \
+    apt-get -q autoremove && \
+    apt-get -q clean -y && rm -rf /var/lib/apt/lists/* && \
+    rm -f /var/cache/apt/*.bin && \
+    locale-gen en_US.UTF-8 && \
+    echo "dash dash/sh boolean false" | debconf-set-selections && \
+    dpkg-reconfigure -f noninteractive dash
+
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
+ENV LC_ALL en_US.UTF-8
+
+## Install Nodejs
+ARG NODEJS_VERSION=14
+RUN curl -sL https://deb.nodesource.com/setup_${NODEJS_VERSION}.x | bash -
+
+# Install Postgres repo
+ARG POSTGRES_VERSION=12
+RUN echo "deb http://apt.postgresql.org/pub/repos/apt/ `lsb_release -cs`-pgdg main" \
+     > /etc/apt/sources.list.d/pgdg.list && \
+    wget -q --no-cookies -O - \
+    https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
+
+# Install google chrome repo
+RUN wget -q --no-cookies -O - \
+    https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - && \
+    echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" \
+    > /etc/apt/sources.list.d/google.list
+
+# Install  packages for our build environment.
+RUN apt-get -q update && \
+    DEBIAN_FRONTEND="noninteractive" apt-get -q install -y \
+    -o Dpkg::Options::="--force-confnew"  --no-install-recommends \
+    openjdk-11-jdk build-essential debhelper lintian fakeroot devscripts jq maven python3 \
+    python3-pip python3-setuptools python3-wheel python3-yaml python3-requests python3-sh nodejs \
+    postgresql-client-${POSTGRES_VERSION} xvfb libgtk2.0-0 libxtst6 libxss1 libgconf-2-4 libnss3 \
+    libnspr4 libasound2 firefox google-chrome-stable libaio1 zip python-is-python3 libyaz5 && \
+    #libnspr4 libasound2 firefox firefox-esr-mozilla-build google-chrome-stable && \
+    #apt-get -q clean -y && rm -rf /var/lib/apt/lists/* && \
+    #rm -f /var/cache/apt/*.bin && \
+    #rm -f /tmp/node.sh && \
+    rm -f /etc/apt/sources.list.d/google.list
+
+RUN npm install -g raml2html@3.0.1 && \
+  npm install -g npm-snapshot
+
+# to be migrated to NPM 7/Node 16 - https://issues.folio.org/browse/STRIPES-676
+ARG YARN_VERSION=1.22.18-1
+RUN wget -O - https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
+    sh -c 'echo "deb https://dl.yarnpkg.com/debian/ stable main" \
+    >> /etc/apt/sources.list.d/yarn.list' && \
+    apt-get -q update && apt-get install -y yarn=${YARN_VERSION} 
+
+# Install Docker cli
+ARG DOCKER_VERSION=20.10.14
+RUN wget -q --no-cookies \
+    https://download.docker.com/linux/static/stable/x86_64/docker-${DOCKER_VERSION}.tgz \
+    -O /tmp/docker.tgz && \
+    cd /tmp && tar zxvf docker.tgz && \
+    mv /tmp/docker/* /usr/local/bin/ && \
+    rm -rf /tmp/docker*
+
+# Install AWS cli tools
+RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && \
+  unzip ./awscliv2.zip -d /tmp && /tmp/aws/install && \
+  rm -rf /tmp/aws && rm ./awscliv2.zip
+
+# Ansible (from pip)
+ARG ANSIBLE_VER=2.9.27
+RUN pip3 install boto && \
+    pip3 install boto3 && \
+    pip3 install jmespath && \
+    pip3 install ansible==${ANSIBLE_VER}
+
+# Install api-doc from folio-org/folio-tools
+RUN cd /usr/local && \
+    git clone https://github.com/folio-org/folio-tools && \
+    cd /usr/local/folio-tools/api-doc && \
+    yarn install && \
+    ln -s /usr/local/folio-tools/api-doc/api_doc.py \
+    /usr/local/bin/api_doc.py && \
+    chmod +x /usr/local/folio-tools/api-doc/api_doc.py
+
+# Install generate_api_docs from folio-org/folio-tools
+# This is deprecated by api-doc
+RUN cd /usr/local/folio-tools/generate-api-docs && \
+    yarn install && \
+    ln -s /usr/local/folio-tools/generate-api-docs/generate_api_docs.py \
+    /usr/local/bin/generate_api_docs.py && \
+    chmod +x /usr/local/folio-tools/generate-api-docs/generate_api_docs.py
+
+# Install api-lint from folio-org/folio-tools
+RUN cd /usr/local/folio-tools/api-lint && \
+    yarn install && \
+    ln -s /usr/local/folio-tools/api-lint/api_lint.py \
+    /usr/local/bin/api_lint.py && \
+    chmod +x /usr/local/folio-tools/api-lint/api_lint.py
+
+# Install api-schema-lint from folio-org/folio-tools
+RUN cd /usr/local/folio-tools/api-schema-lint && \
+    ln -s /usr/local/folio-tools/api-schema-lint/api_schema_lint.py \
+    /usr/local/bin/api_schema_lint.py && \
+    chmod +x /usr/local/folio-tools/api-schema-lint/api_schema_lint.py
+
+# Install lint_raml_cop from folio-org/folio-tools
+# This is deprecated by api-lint
+RUN cd /usr/local/folio-tools/lint-raml && \
+    yarn install && \
+    ln -s /usr/local/folio-tools/lint-raml/lint_raml_cop.py \
+    /usr/local/bin/lint_raml_cop.py && \
+    chmod +x /usr/local/folio-tools/lint-raml/lint_raml_cop.py
+
+# docker build '--build-arg' and their FOLIO CI defaults
+ARG user=jenkins
+ARG user_email=folio-jenkins@indexdata.com
+ARG group=jenkins
+ARG uid=497
+ARG gid=1000
+ARG docker_gid=496
+ARG docker_user=jenkins
+
+ARG JENKINS_AGENT_HOME=/home/${user}
+
+ENV JENKINS_AGENT_HOME ${JENKINS_AGENT_HOME}
+
+RUN groupadd -g ${gid} ${group} \
+    && useradd -d "${JENKINS_AGENT_HOME}" -u "${uid}" -g "${gid}" -m -s /bin/bash "${user}" \
+    && groupadd -g ${docker_gid} docker \
+    && usermod -a -G docker ${docker_user} \
+    && bash -c "echo '${user} ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/folio" \
+    && bash -c "echo '[user]' > ${JENKINS_AGENT_HOME}/.gitconfig" \
+    && bash -c "echo '  email = ${user_email}' >> ${JENKINS_AGENT_HOME}/.gitconfig" \
+    && bash -c "echo '  name  = ${user}' >> ${JENKINS_AGENT_HOME}/.gitconfig" \
+    && yarn config set registry https://repository.folio.org/repository/npm-ci-all \
+    && mv /usr/local/share/.yarnrc ${JENKINS_AGENT_HOME} \
+    && chown -R ${user}.${group} ${JENKINS_AGENT_HOME}
+
+# Run as user, $user,to install sdkman for Gradle
+RUN su - ${user} -s /bin/bash -c 'curl -s "https://get.sdkman.io" | bash \
+    && source "/home/jenkins/.sdkman/bin/sdkman-init.sh" \
+    && sdk install gradle 6.6.1'
+
+COPY setup-sshd /usr/local/bin/setup-sshd
+
+VOLUME "${JENKINS_AGENT_HOME}" "/tmp" "/run" "/var/run" "/var/run/docker.sock"
+WORKDIR "${JENKINS_AGENT_HOME}"
+
+EXPOSE 22
+
+ENTRYPOINT ["setup-sshd"]
+

--- a/jenkins-slave-docker/NEWS.md
+++ b/jenkins-slave-docker/NEWS.md
@@ -1,3 +1,10 @@
+## 3.0.0 2022-05-12
+
+* Build "java-17" image from Dockerfile.jammy-java-17 [FOLIO-3494](https://issues.folio.org/browse/FOLIO-3494)
+* Use Ubuntu 22.04 LTS (Jammy Jellyfish) [FOLIO-3478](https://issues.folio.org/browse/FOLIO-3478)
+* Use OpenJDK 17.0.3
+* Use NodeJS LTS v16 (16.15.0) [FOLIO-3434](https://issues.folio.org/browse/FOLIO-3434)
+
 ## 2.9.6 2022-05-10
 
 * Update api-lint FOLIO-3486

--- a/jenkins-slave-docker/README.md
+++ b/jenkins-slave-docker/README.md
@@ -26,24 +26,23 @@ Docker CLI tools contained in the image, docker_gid must match the same gid set 
  * docker_user=jenkins
  * docker_gid=496  # The GID of the docker group on the docker daemon host.
 
-Example build and run commands for the image:
+Example build and run commands for the image (here showing "`java-17`"):
 
 ```
-'docker build -f Dockerfile  -t folioci/jenkins-slave-all:java-11 .'
+'docker build -f Dockerfile  -t folioci/jenkins-slave-all:java-17 .'
 
 'docker run -d -p 127.0.0.1:2222:22 -v /var/run/docker.sock:/var/run/docker.sock \
    -e "JENKINS_SLAVE_SSH_PUBKEY=<YOUR PUBLIC SSH KEY HERE>" \
-   folioci/jenkins-slave-all:java-11'
+   folioci/jenkins-slave-all:java-17'
 ```
 
 ## Upgrading this image
 
 * Pick a new version number (Check [NEWS.md](NEWS.md) or https://hub.docker.com/r/folioci/jenkins-slave-all/tags?page=1&ordering=last_updated for the latest tag)
 * List changes in the NEWS.md file
-* Build and tag and push the new image as "java-11-test".
-* Temporarily enable "Jenkins Slave02" host.
-* Verify various builds (e.g. folio-snapshot-test, backend repo, frontend repo) using buildNode `jenkins-agent-test` rather than the default `jenkins-agent-java11`
-* Tag and push the new image with the new version tag and "java-11". Jenkins will pull the image tagged "java-11".
+* Build and tag and push the new image as "java-17-test" (or "java-11-test" for the previous).
+* Verify various builds (e.g. folio-snapshot-test, backend repo, frontend repo) using buildNode `jenkins-agent-java17-test` rather than the default `jenkins-agent-java17`
+* After satisfied with tests, then tag and push the new image with the new version tag and "java-17". Jenkins will pull the image tagged "java-17".
 * 2020-12-30: The "latest" tag refers to the deprecated 1.x series "java-8" image.
 
 If it's necessary to revert to an older image, use docker pull to get an older version, tag it as "java-11" and push it back up.


### PR DESCRIPTION
See [FOLIO-3494](https://issues.folio.org/browse/FOLIO-3494)
* Use Ubuntu 22.04 LTS (Jammy Jellyfish) [FOLIO-3478](https://issues.folio.org/browse/FOLIO-3478)
* Use OpenJDK 17.0.3
* Use NodeJS LTS v16 (16.15.0) [FOLIO-3434](https://issues.folio.org/browse/FOLIO-3434)