### PR TITLE
FOLIO-3507: Remove curl from folioci/alpine-jre-openjdk-17

### DIFF
--- a/folio-java-docker/openjdk17/Dockerfile
+++ b/folio-java-docker/openjdk17/Dockerfile
@@ -13,7 +13,6 @@ ENV JAVA_APP_DIR=/usr/verticles \
 # as the fix is still not in the temurin images.
 RUN apk upgrade \
  && apk add \
-      curl \
       # https://issues.folio.org/browse/FOLIO-3406 libc6-compat for OpenSSL
       libc6-compat \
  && rm -rf /var/cache/apk/*

--- a/folio-java-docker/openjdk17/README.md
+++ b/folio-java-docker/openjdk17/README.md
@@ -31,6 +31,22 @@ COPY target/${VERTICLE_FILE} ${VERTICLE_HOME}/${VERTICLE_FILE}
 EXPOSE 8081
 ```
 
+### No curl, use wget
+
+While curl is in folioci/alpine-jre-openjdk11 it has been removed from
+folioci/alpine-jre-openjdk17 for the reasons explained in
+https://issues.folio.org/browse/FOLIO-3407
+
+In Jenkinsfile change
+
+```
+healthChkCmd = 'curl -sS --fail -o /dev/null  http://localhost:8081/admin/health || exit 1'
+```
+to
+```
+healthChkCmd = 'wget --no-verbose --tries=1 --spider http://localhost:8081/admin/health || exit 1'
+```
+
 ### Note about shell
 
 Most modules do not add their own shell scripts to the container. Those that do, will need to


### PR DESCRIPTION
Remove curl from folioci/alpine-jre-openjdk-17 for the reasons explained in
https://issues.folio.org/browse/FOLIO-3407

Tracking affected modules: https://github.com/search?q=%22folioci%2Falpine-jre-openjdk17%22&type=code

mod-meta-storage has switched from curl to wget: https://github.com/folio-org/mod-meta-storage/blob/master/Jenkinsfile