### PR TITLE
update python deps to avoid security alerts

### DIFF
--- a/kubernetes-utilities/md2kubeyaml/requirements.txt
+++ b/kubernetes-utilities/md2kubeyaml/requirements.txt
@@ -1,8 +1,8 @@
 certifi==2019.6.16
 chardet==3.0.4
 idna==2.8
-Jinja2==2.10.1
+Jinja2==2.11.3
 MarkupSafe==1.1.1
 pkg-resources==0.0.0
 requests==2.22.0
-urllib3==1.25.3
+urllib3==1.26.5

--- a/vufind-indexer/requirements.txt
+++ b/vufind-indexer/requirements.txt
@@ -3,4 +3,4 @@ chardet==3.0.4
 idna==2.8
 jmespath==0.9.4
 requests==2.22.0
-urllib3==1.25.6
+urllib3==1.26.5


### PR DESCRIPTION
Update `urllib3`, `jinja2` to avoid security alerts.

@ihardy, @julianladisch: I noticed a dependabot alert in this repo while updating another script. The updates here are compatible according to semver, but I don't know how to test these scripts to validate that the changes are in fact safe. I would appreciate if you could test it and merge this if it looks good to you. 