### PR TITLE
Update docker compose version in docker-compose.yml.

### DIFF
--- a/infrastructure/local/docker-compose.yml
+++ b/infrastructure/local/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "3"
+version: "3.7"
 services:
   postgres:
     image: "postgres:12-alpine"


### PR DESCRIPTION
Docker compose complains about networks.default.name not being valid.
As a result docker compose will not run.

Changing the version number to a more recent version, such as 3.7, fixes the problem.