### PR TITLE
Fix typos discovered by codespell

### DIFF
--- a/add-users/add-users.js
+++ b/add-users/add-users.js
@@ -410,7 +410,7 @@ const handlePort = (i, config) => {
  * handleOkapi
  * set options.hostname and optionally options.port. Configure the request
  * handler based on the URL prefix (http or https), but note this will
- * overriden by the port handler if a port is present.
+ * overridden by the port handler if a port is present.
  * @arg string a URL, e.g. https://www.example.edu
  */
 const handleOkapi = (i, config) => {

--- a/folio-java-docker/openjdk11/run-java.sh
+++ b/folio-java-docker/openjdk11/run-java.sh
@@ -12,7 +12,7 @@
 #
 #
 # This script will pick up either a 'fat' jar which can be run with "-jar"
-# or you can sepcify a JAVA_MAIN_CLASS.
+# or you can specify a JAVA_MAIN_CLASS.
 #
 # Source and Documentation can be found
 # at https://github.com/fabric8io-images/run-java-sh
@@ -36,7 +36,7 @@
 # of other memory areas (metadata, thread, code cache, ...) which adds to the overall
 # size. When your container gets killed because of an OOM, then you should tune
 # the absolute values.
-# JAVA_INIT_MEM_RATIO: Ratio use to calculate a default intial heap memory, in percent.
+# JAVA_INIT_MEM_RATIO: Ratio use to calculate a default initial heap memory, in percent.
 #                      By default this value is not set.
 #
 # The following variables are exposed to your Java application:
@@ -324,7 +324,7 @@ calc_max_memory() {
   # Check for the 'real memory size' and calculate Xmx from the ratio
   if [ -n "${JAVA_MAX_MEM_RATIO:-}" ]; then
     if [ "${JAVA_MAX_MEM_RATIO}" -eq 0 ]; then
-      # Explicitely switched off
+      # Explicitly switched off
       return
     fi
     calc_mem_opt "${CONTAINER_MAX_MEMORY}" "${JAVA_MAX_MEM_RATIO}" "mx"

--- a/folio-java-docker/openjdk17/run-java.sh
+++ b/folio-java-docker/openjdk17/run-java.sh
@@ -12,7 +12,7 @@
 #
 #
 # This script will pick up either a 'fat' jar which can be run with "-jar"
-# or you can sepcify a JAVA_MAIN_CLASS.
+# or you can specify a JAVA_MAIN_CLASS.
 #
 # Source and Documentation can be found
 # at https://github.com/fabric8io-images/run-java-sh
@@ -36,7 +36,7 @@
 # of other memory areas (metadata, thread, code cache, ...) which adds to the overall
 # size. When your container gets killed because of an OOM, then you should tune
 # the absolute values.
-# JAVA_INIT_MEM_RATIO: Ratio use to calculate a default intial heap memory, in percent.
+# JAVA_INIT_MEM_RATIO: Ratio use to calculate a default initial heap memory, in percent.
 #                      By default this value is not set.
 #
 # The following variables are exposed to your Java application:
@@ -324,7 +324,7 @@ calc_max_memory() {
   # Check for the 'real memory size' and calculate Xmx from the ratio
   if [ -n "${JAVA_MAX_MEM_RATIO:-}" ]; then
     if [ "${JAVA_MAX_MEM_RATIO}" -eq 0 ]; then
-      # Explicitely switched off
+      # Explicitly switched off
       return
     fi
     calc_mem_opt "${CONTAINER_MAX_MEMORY}" "${JAVA_MAX_MEM_RATIO}" "mx"

--- a/folio-java-docker/openjdk8/README.md
+++ b/folio-java-docker/openjdk8/README.md
@@ -20,7 +20,7 @@ and Prometheus remote JMX-based agents.  https://github.com/fabric8io/agent-bond
 * The Fabric8 entrypoint script called 'run-java.sh' is also included and is used to 
 start all java-based applications in the Docker container.   
 
-* Intelligent JVM CPU and memory resource allocation based on container resource contraints.
+* Intelligent JVM CPU and memory resource allocation based on container resource constraints.
 
 
 The following container runtime configuration information is copied verbatim 

--- a/folio-java-docker/openjdk8/java-default-options
+++ b/folio-java-docker/openjdk8/java-default-options
@@ -18,7 +18,7 @@
 #                             https://www.youtube.com/watch?v=w1rZOY5gbvk
 #                             https://vimeo.com/album/4133413/video/181900266
 # Also note that heap is only a small portion of the memory used by a JVM. There are lot
-# of other memory areas (metadata, thread, code cache, ...) which addes to the overall
+# of other memory areas (metadata, thread, code cache, ...) which adds to the overall
 # size. There is no easy solution for this, 50% seems to be are reasonable compromise.
 # However, when your container gets killed because of an OOM, then you should tune
 # the absolute values
@@ -32,12 +32,12 @@ max_memory() {
     return
   fi
 
-  # Check if explicitely disabled
+  # Check if explicitly disabled
   if [ "x$JAVA_MAX_MEM_RATIO" = "x0" ]; then
     return
   fi
 
-  # Check for the 'real memory size' and caluclate mx from a ratio
+  # Check for the 'real memory size' and calculate mx from a ratio
   # given (default is 50%)
   if [ "x$CONTAINER_MAX_MEMORY" != x ]; then
     local max_mem="${CONTAINER_MAX_MEMORY}"

--- a/kubernetes-utilities/ci-cleanup/module-cleanup/README.md
+++ b/kubernetes-utilities/ci-cleanup/module-cleanup/README.md
@@ -1,5 +1,5 @@
 # ci-cleanup
-Cleans up FOLIO backend modules running in a kubernetes cluster. Modules must have be labled according the the following scheme:
+Cleans up FOLIO backend modules running in a kubernetes cluster. Modules must have be labeled according the the following scheme:
 | label      | description                                                                                  | example          |
 |------------|----------------------------------------------------------------------------------------------|------------------|
 | app        | full name of backend module with version. Colons and periods should be replaced with hyphens | mod-users-15-6-1 |

--- a/kubernetes-utilities/ci-cleanup/tenant-cleanup/tenant-cleanup.py
+++ b/kubernetes-utilities/ci-cleanup/tenant-cleanup/tenant-cleanup.py
@@ -78,7 +78,7 @@ def delete_tenant(okapi_url, tenant, token):
                         headers=headers)
     
     if r.status_code == 204:
-        print("sucessfully deleted {}".format(tenant))
+        print("successfully deleted {}".format(tenant))
         deleted = True
     else:
         r.raise_for_status()

--- a/lint-raml/lint_raml_cop.py
+++ b/lint-raml/lint_raml_cop.py
@@ -325,7 +325,7 @@ def main():
             logger1.debug("Found %s declared schemas or types files.", len(schemas))
             if issues_flag:
                 exit_code = 1
-            # Ensure each $ref referenced schema file exists, is useable, and is declared in the RAML
+            # Ensure each $ref referenced schema file exists, is usable, and is declared in the RAML
             for schema in schemas:
                 schema_pn = os.path.normpath(os.path.join(ramls_dir, schemas[schema]))
                 if not os.path.exists(schema_pn):
@@ -505,7 +505,7 @@ def gather_declarations(raml_input_pn, raml_input_fn, raml_version, is_rmb, inpu
                     except KeyError:
                         logger.error("Missing declaration in '%s' for schema $ref '%s' used in 'validation.raml'", raml_input_fn, schema_key)
                         issues = True
-        # Some old traits must not be declared in new RMB, and will cause wierd messages
+        # Some old traits must not be declared in new RMB, and will cause weird messages
         if raml_version != "0.8":
             traits_excluded = ["auth.raml"]
             for trait in traits:

--- a/okapi-request/lib/OkapiRequest.js
+++ b/okapi-request/lib/OkapiRequest.js
@@ -142,7 +142,7 @@ class OkapiRequest
      * handleOkapi
      * set options.hostname and optionally options.port. Configure the request
      * handler based on the URL prefix (http or https), but note this will be
-     * overriden by the port handler if a port is present.
+     * overridden by the port handler if a port is present.
      * @arg string a URL, e.g. https://www.example.edu
      */
     const handleOkapi = (i, config) => {


### PR DESCRIPTION
[`codespell --ignore-words-list=inflight,nin,ths .`](https://pypi.org/project/codespell)