### PR TITLE
FOLIO-3731: api_doc: json-ptr ^3.0.0, marked ^2.0.0, underscore ^1.12.1

### DIFF
--- a/api-doc/api_doc.py
+++ b/api-doc/api_doc.py
@@ -29,7 +29,7 @@ import tempfile
 import sh
 import yaml
 
-SCRIPT_VERSION = "1.5.1"
+SCRIPT_VERSION = "1.5.2"
 
 LOGLEVELS = {
     "debug": logging.DEBUG,

--- a/api-doc/package.json
+++ b/api-doc/package.json
@@ -12,5 +12,10 @@
     "eslint": "^8.2.0",
     "eslint-plugin-import": "^2.25.2",
     "eslint-config-airbnb-base": "latest"
+  },
+  "resolutions": {
+    "**/json-ptr": "^3.0.0",
+    "**/marked": "^2.0.0",
+    "**/underscore": "^1.12.1"
   }
 }


### PR DESCRIPTION
api-doc/deref-schema.js uses vulnerable indirect dependencies.

We only fix the most critical ones.

Upgrade json-ptr from 0.1.1 to >= 3.0.0 fixing Prototype Pollution: https://nvd.nist.gov/vuln/detail/CVE-2021-23509

Upgrade underscore from 1.9.1 to >= 1.12.1 fixing Arbitrary Code Injection: Arbitrary Code Injection: https://nvd.nist.gov/vuln/detail/CVE-2021-23358

Upgrade marked from 1.2.9 to >= 2.0.0 fixing Regular Expression Denial of Service (ReDoS): https://nvd.nist.gov/vuln/detail/CVE-2021-21306

marked cannot be upgrade to >= 4.0.10 to fix more vulnerabilities because the major version bump from 2 to 4 causes a runtime failure.

The three upgrades have been tested with these modules:
* mod-courses
* mod-feesfines
* mod-finance
* mod-finance-storage
* mod-orders
* mod-orders-storage
* mod-users
* mod-users-bl

The output in ~/folio-api-docs is exactly the same (when ignoring "generatedDate" and "generator" version in config-doc.json).