### PR TITLE
FOLIO-3884: certifi 2023.7.22, requests 2.31.0 fixing CVEs

### DIFF
--- a/kubernetes-utilities/ci-cleanup/module-cleanup/requirements.txt
+++ b/kubernetes-utilities/ci-cleanup/module-cleanup/requirements.txt
@@ -1,5 +1,5 @@
 cachetools==3.1.1
-certifi==2019.9.11
+certifi==2023.7.22
 chardet==3.0.4
 google-auth==1.7.0
 idna==2.8
@@ -10,7 +10,7 @@ pyasn1==0.4.7
 pyasn1-modules==0.2.7
 python-dateutil==2.8.1
 PyYAML==5.4
-requests==2.22.0
+requests==2.31.0
 requests-oauthlib==1.2.0
 rsa==4.8
 six==1.13.0

--- a/kubernetes-utilities/md2kubeyaml/requirements.txt
+++ b/kubernetes-utilities/md2kubeyaml/requirements.txt
@@ -1,8 +1,8 @@
-certifi==2019.6.16
+certifi==2023.7.22
 chardet==3.0.4
 idna==2.8
 Jinja2==2.11.3
 MarkupSafe==1.1.1
 pkg-resources==0.0.0
-requests==2.22.0
+requests==2.31.0
 urllib3==1.26.5

--- a/vufind-indexer/requirements.txt
+++ b/vufind-indexer/requirements.txt
@@ -1,6 +1,6 @@
-certifi==2019.9.11
+certifi==2023.7.22
 chardet==3.0.4
 idna==2.8
 jmespath==0.9.4
-requests==2.22.0
+requests==2.31.0
 urllib3==1.26.5


### PR DESCRIPTION
Upgrade certifi from 2019.9.11 to 2023.7.22 fixing Improper Following of a Certificate's Chain of Trust regarding "e-Tugra" root certificates: https://nvd.nist.gov/vuln/detail/CVE-2023-37920

Upgrade requests from 2.22.0 to 2.31.0 fixing Information Exposure: https://nvd.nist.gov/vuln/detail/CVE-2023-32681