### PR TITLE
FOLIO-3976: maven 3.8 for folioci/jenkins-slave-all

### DIFF
--- a/jenkins-slave-docker/Dockerfile.jammy-java-17
+++ b/jenkins-slave-docker/Dockerfile.jammy-java-17
@@ -52,7 +52,7 @@ RUN wget -q --no-cookies -O - \
 RUN apt-get -q update && \
     DEBIAN_FRONTEND="noninteractive" apt-get -q install -y \
     -o Dpkg::Options::="--force-confnew"  --no-install-recommends \
-    openjdk-17-jdk build-essential debhelper lintian fakeroot devscripts jq maven python3 \
+    openjdk-17-jdk build-essential debhelper lintian fakeroot devscripts jq python3 \
     python3-pip python3-setuptools python3-wheel python3-yaml python3-requests python3-sh nodejs \
     postgresql-client-${POSTGRES_VERSION} xvfb libgtk2.0-0 libxtst6 libxss1 libgconf-2-4 libnss3 \
     libnspr4 libasound2 firefox google-chrome-stable libaio1 zip python-is-python3 libyaz5 && \
@@ -61,6 +61,15 @@ RUN apt-get -q update && \
     #rm -f /var/cache/apt/*.bin && \
     #rm -f /tmp/node.sh && \
     rm -f /etc/apt/sources.list.d/google.list
+
+# Install maven 3.8
+RUN wget -q --no-cookie https://dlcdn.apache.org/maven/maven-3/3.8.8/binaries/apache-maven-3.8.8-bin.tar.gz -O /tmp/maven.tgz && \
+    echo '332088670d14fa9ff346e6858ca0acca304666596fec86eea89253bd496d3c90deae2be5091be199f48e09d46cec817c6419d5161fb4ee37871503f472765d00 /tmp/maven.tgz' | \
+    sha512sum -c --quiet && \
+    tar -xf /tmp/maven.tgz -C /opt && \
+    mv /opt/apache-maven-* /opt/maven && \
+    sed -i 's!^PATH="!PATH="/opt/maven/bin:!' /etc/environment && \
+    rm /tmp/maven.tgz
 
 RUN npm install -g raml2html@3.0.1 && \
   npm install -g npm-snapshot

--- a/jenkins-slave-docker/NEWS.md
+++ b/jenkins-slave-docker/NEWS.md
@@ -1,7 +1,8 @@
-## 3.0.12 java-17 2024-02-06
+## 3.0.12 java-17 2024-02-13
 
 * Update OS to latest jammy-updates
 * Upgrade maven to 3.8.8
+* Upgrade Nodejs to 18.19.0
 
 ## 3.0.11 java-17 2023-10-18
 

--- a/jenkins-slave-docker/NEWS.md
+++ b/jenkins-slave-docker/NEWS.md
@@ -1,3 +1,8 @@
+## 3.0.12 java-17 2024-02-06
+
+* Update OS to latest jammy-updates
+* Upgrade maven to 3.8.8
+
 ## 3.0.11 java-17 2023-10-18
 
 * Update OS to latest jammy-updates 


### PR DESCRIPTION
jenkins-slave-docker/Dockerfile.jammy-java-17
installs the maven version Jammy ships with: 3.6.3-5

Since Orchid FOLIO requires maven 3.8:
https://folio-org.atlassian.net/wiki/spaces/TC/pages/5054392/Orchid#Orchid-Buildtools.1

Solution: Install maven 3.8.8.