### PR TITLE
[STRIPES-930] Update version calculation

### DIFF
--- a/github-actions-scripts/folioci_npmver.sh
+++ b/github-actions-scripts/folioci_npmver.sh
@@ -27,8 +27,10 @@ fi
 
 new_cur_ver=${maj_ver}.${min_ver}.${patch_ver}
 
-# add 000+Jenkins JOB_ID to current patch version
+# add 00009999+CI JOB_ID to current patch version
+# 9999 is here due to a change in CI workflows (STRIPES-904) which reset job IDs;
+# without them, newer builts may have smaller version numbers
 
-new_snap_ver=${new_cur_ver}00000${JOB_ID}
+new_snap_ver=${new_cur_ver}00009999${JOB_ID}
 echo "$new_snap_ver"
 

--- a/github-actions-scripts/folioci_npmver.sh
+++ b/github-actions-scripts/folioci_npmver.sh
@@ -31,6 +31,6 @@ new_cur_ver=${maj_ver}.${min_ver}.${patch_ver}
 # 9999 is here due to a change in CI workflows (STRIPES-904) which reset job IDs;
 # without them, newer builts may have smaller version numbers
 
-new_snap_ver=${new_cur_ver}00009999${JOB_ID}
+new_snap_ver=${new_cur_ver}09000000${JOB_ID}
 echo "$new_snap_ver"
 


### PR DESCRIPTION
This should work for packages that had thousands of the old job run and very few of the new one (up to a three figure difference, e.g. old #2378 and new #27). Quick looks at several repos appeared to have nothing more extreme than that.

```
old: new_snap_ver=${new_cur_ver}000002378
new: new_snap_ver=${new_cur_ver}0000999927
```