### PR TITLE
[STRIPES-930] Add new CI version number handling

### DIFF
--- a/github-actions-scripts/folioci_npmver.sh
+++ b/github-actions-scripts/folioci_npmver.sh
@@ -29,11 +29,11 @@ new_cur_ver=${maj_ver}.${min_ver}.${patch_ver}
 
 # add 09000000+CI JOB_ID to current patch version
 # the extra numbers is here due to a change in CI workflows (STRIPES-904) which reset job IDs; without them, newer builts may have smaller version numbers.
-# we also provide $new_ci as an input for the new CI script to use to ensure we always have a higher build number upon switchover
+# we also provide $new_ci as an input for the new CI script with more nines to use to ensure we always have a higher build number upon switchover
 
-new_snap_ver=${new_cur_ver}09000000${JOB_ID}
+  new_snap_ver=${new_cur_ver}09000000${JOB_ID}
 if [ -z "$new_ci" ]; then
-  new_snap_ver=${new_cur_ver}09900000${JOB_ID}
+  new_snap_ver=${new_cur_ver}0999999000000${JOB_ID}
 fi
 
 echo "$new_snap_ver"

--- a/github-actions-scripts/folioci_npmver.sh
+++ b/github-actions-scripts/folioci_npmver.sh
@@ -27,10 +27,13 @@ fi
 
 new_cur_ver=${maj_ver}.${min_ver}.${patch_ver}
 
-# add 00009999+CI JOB_ID to current patch version
-# 9999 is here due to a change in CI workflows (STRIPES-904) which reset job IDs;
-# without them, newer builts may have smaller version numbers
+# add 09000000+CI JOB_ID to current patch version
+# the extra numbers is here due to a change in CI workflows (STRIPES-904) which reset job IDs; without them, newer builts may have smaller version numbers.
+# we also provide $new_ci as an input for the new CI script to use to ensure we always have a higher build number upon switchover
 
 new_snap_ver=${new_cur_ver}09000000${JOB_ID}
-echo "$new_snap_ver"
+if [ -z "$new_ci" ]; then
+  new_snap_ver=${new_cur_ver}09900000${JOB_ID}
+fi
 
+echo "$new_snap_ver"


### PR DESCRIPTION
We previously added `09000000` to snapshot versions to ensure that new workflow usage would supercede historic old workflow version numbers. However, we need to handle the case where, after the previous change, a module upgrades from the old to new workflows.