### PR TITLE
Fix incorrect logic in snapshot version generation

### DIFF
--- a/github-actions-scripts/folioci_npmver.sh
+++ b/github-actions-scripts/folioci_npmver.sh
@@ -33,7 +33,7 @@ new_cur_ver=${maj_ver}.${min_ver}.${patch_ver}
 
 new_snap_ver=${new_cur_ver}09000000${JOB_ID}
 if [ -n "$new_ci" ]; then
-  new_snap_ver=${new_cur_ver}09999000000${JOB_ID}
+  new_snap_ver=${new_cur_ver}09900000000${JOB_ID}
 fi
 
 echo "$new_snap_ver"

--- a/github-actions-scripts/folioci_npmver.sh
+++ b/github-actions-scripts/folioci_npmver.sh
@@ -31,9 +31,9 @@ new_cur_ver=${maj_ver}.${min_ver}.${patch_ver}
 # the extra numbers is here due to a change in CI workflows (STRIPES-904) which reset job IDs; without them, newer builts may have smaller version numbers.
 # we also provide $new_ci as an input for the new CI script with more nines to use to ensure we always have a higher build number upon switchover
 
-  new_snap_ver=${new_cur_ver}09000000${JOB_ID}
-if [ -z "$new_ci" ]; then
-  new_snap_ver=${new_cur_ver}0999999000000${JOB_ID}
+new_snap_ver=${new_cur_ver}09000000${JOB_ID}
+if [ -n "$new_ci" ]; then
+  new_snap_ver=${new_cur_ver}09999000000${JOB_ID}
 fi
 
 echo "$new_snap_ver"


### PR DESCRIPTION
🤦 #323 had the incorrect bash test condition, resulting in the new_ci version number being used when it should not have been.

Additionally, it seems npm's `semver` is limited to 16 characters per part of the version number. This reduces `new_snap_ver` to fit within that constraint (assuming job_id is <10000):

```
old CI versions:
1090000001
1090000009999
^ patch  ^^^^ build number
 ^^^^^^^^ constant

new CI versions:
1099990000001
1099990000009999
^ patch     ^^^^ build number
 ^^^^^^^^^^^ constant
```

Unfortunately, `new_ci` versions have to be this long, as they have to be longer than the old CI versions. We will also need to manually purge the previous attempts (containing `0999999000000`) from Nexus.