### PR TITLE
provide a "user-admin" user with appropriate permissions

### DIFF
--- a/add-users/psets/user-admin.json
+++ b/add-users/psets/user-admin.json
@@ -1,0 +1,6 @@
+[
+  "Users: Can view user profile",
+  "Users: Can edit user profile",
+  "Users: Can create and edit users",
+  "Settings (developer): Can change users' passwords"
+]


### PR DESCRIPTION
Provide `user-admin` with permission to view, create, and edit users and to set their passwords via developer tools. This will simplify the process of [restoring locked accounts in the reference environments](https://folio-project.slack.com/archives/CFQU1MF61/p1727865874665179?thread_ts=1727863341.432989&cid=CFQU1MF61) where these accounts are used.

@dcrossleyau, it feels like I should ask somebody for permission before adding a privileged user to the reference envs. Are you that person? If not, do you know who is? 