### PR TITLE
FOLIO-4362 handle patch values > 8, build values > 999

### DIFF
--- a/github-actions-scripts/folioci_npmver.sh
+++ b/github-actions-scripts/folioci_npmver.sh
@@ -1,39 +1,100 @@
-#!/bin/bash
+#!/usr/bin/env node
 
-# for testing only
-#BUILD_NUMBER=123
+/**
+ * SUMMARY
+ *
+ * derive a semver-compatible value from ./package.json's version and the build-number
+ *
+ *
+ * USAGE
+ *
+ * JOB_ID=123 ./$0              // output like 11.1.109000000123
+ * JOB_ID=1234 ./$0             // output like 11.1.109000001234
+ * JOB_ID=123 new_ci=true ./$0  // output like 11.1.10990000000123
+ * JOB_ID=1234 new_ci=true ./$0 // output like 11.1.10990000001234
+ *
+ *
+ * DETAILS
+ *
+ * Given package.json contains a version value like `1.2.0` or `2.3.4` and
+ * the environment variable JOB_ID contains a build-number like 456, concoct
+ * a version number like `1.2.109000000456` or `2.3.409000000456` and print it.
+ *
+ * When the environment variable new_ci is truthy, the generated patch value
+ * is padded to 14-16 places with a prefix of ${patch}099. Otherwise, the
+ * generated patch value is padded to 12-14 places with a prefix of ${patch}09.
+ *
+ * Exits 0 on success, 2 if package.json is not found, and 3 in case of any
+ * other error.
+ *
+ * The max patch value from package.json is 900.
+ *
+ * The max JOB_ID is 9_999_999_999 when new_ci is true, 999_999_999 without it.
+ *
+ * Why oh why do we do it this way? A long time ago, on a Jenkins server far
+ * far away, tacking the build-number onto the patch-version was chosen as a
+ * quick way to create incremental builds when making a commit to master and
+ * auto-publishing this resulting build as a new version to the CI server.
+ * After a server migration, build-numbers restarted at 1, wreaking havoc with
+ * this scheme since new builds were generating semantically lower versions,
+ * hence the introduction of `new_ci`. We ... messed up a few times, hence the
+ * padding with 09, or 099
+ *
+ * Point of interest, or maybe disinterest: the max JOB_ID and patch values
+ * derive from needing to keep the final value below  2^53 -1,
+ * 9_007_199_254_740_991, the maximum value as of npm 10.9.2. This script was
+ * written to replace the old bash script which simply concatenated the
+ * build-number onto the end instead of padding to a constant width, causing
+ * grief with a patch value of 9 and a build-number greater than 999:
+ *   yarn version --new-version 11.0.9099000000001021
+ *   error Invalid version supplied.
+ *
+ *
+ */
+const main = ({ buildId, newCi }) => {
+  try {
+    const pkg = require(`${process.env.PWD}/package.json`);
+    if (!pkg) {
+      console.error("package.json file not found");
+      process.exit(2);
+    }
 
-if [ ! -e package.json ]; then
-   echo "package.json file not found"
-   exit 2
-fi
+    const buildNumber = Number.parseInt(buildId, 10);
+    if (!buildNumber) {
+      throw new Error(`could not parse buildId: '${buildId}'`)
+    }
+    const isNewCi = !!newCi;
 
-hasjq=`which jq`
+    // from https://semver.org/
+    const regex = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$/;
+    const [ver, vmajor, vminor, vpatch] = pkg.version.match(regex);
 
-if [ -z "$hasjq" ]; then
-  echo "jq not found"
-  exit 2
-fi
+    const patchNumber = Number.parseInt(vpatch, 10);
+    if (patchNumber && patchNumber > 900) {
+      throw new Error(`patch number cannot exceed 900 ('${vpatch}')`)
+    }
 
-cur_ver=`cat package.json | jq -r .version`
+    // patch must parse as a number, i.e. can be 0 but not start with 0.
+    const patch = (vpatch === "0") ? "1" : vpatch;
+    const snapshot = `${vmajor}.${vminor}.${patch}`;
 
-maj_ver=$(echo $cur_ver | awk -F '.' '{ print $1 }')
-min_ver=$(echo $cur_ver | awk -F '.' '{ print $2 }')
-patch_ver=$(echo $cur_ver | awk -F '.' '{ print $3 }')
+    // padding is a constant width based on the magnitude of buildNumber
+    // repeat() will throw if magnitude is too great, resulting in < 0
+    const magnitude = Math.floor(Math.log10(buildNumber));
+    const pad = isNewCi ? `099${'0'.repeat(9 - magnitude)}` : `09${'0'.repeat(8 - magnitude)}`;
 
-if [ "$patch_ver" == "0" ]; then
-  patch_ver=1
-fi
+    return `${snapshot}${pad}${buildNumber}`
 
-new_cur_ver=${maj_ver}.${min_ver}.${patch_ver}
+  } catch (e) {
+    if (e.message.startsWith('Cannot find module')) {
+      console.error('package.json file not found')
+      process.exit(2);
+    }
+    console.error(e.message);
+    process.exit(3);
+  }
+}
 
-# add 09000000+CI JOB_ID to current patch version
-# the extra numbers is here due to a change in CI workflows (STRIPES-904) which reset job IDs; without them, newer builts may have smaller version numbers.
-# we also provide $new_ci as an input for the new CI script with more nines to use to ensure we always have a higher build number upon switchover
+const version = main({ buildId: process.env.JOB_ID, newCi: process.env.new_ci });
+console.log(version);
 
-new_snap_ver=${new_cur_ver}09000000${JOB_ID}
-if [ -n "$new_ci" ]; then
-  new_snap_ver=${new_cur_ver}09900000000${JOB_ID}
-fi
-
-echo "$new_snap_ver"

--- a/github-actions-scripts/folioci_npmver.sh
+++ b/github-actions-scripts/folioci_npmver.sh
@@ -3,7 +3,7 @@
 /**
  * SUMMARY
  *
- * derive a semver-compatible value from ./package.jsons version and the build-number
+ * derive a semver-compatible value from ./package.json's version and the build-number
  *
  *
  * USAGE
@@ -73,7 +73,7 @@ const main = ({ buildId, newCi }) => {
     }
     const isNewCi = !!newCi;
 
-    // it's tempting to think a smaller, simply regex would be sufficient
+    // it's tempting to think a smaller, simpler regex would be sufficient
     // here, but since semver org suggests a reg, we'll accept the offer.
     // from https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
     const regex = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$/;
@@ -89,6 +89,9 @@ const main = ({ buildId, newCi }) => {
     // values onto the end, the result needs to be parseable as a number, and
     // thus cannot start with 0. the simple hack here is to convert 0 to 1,
     // meaning input like `1.2.0` provides output like `1.2.109000000123`.
+    // treating 0 and 1 the same might seem problematic, but we don't have to
+    // worry about collisions because the build-numbers we tack on at the end
+    // always increase, leading to unique values.
     const patch = (vpatch === "0") ? "1" : vpatch;
     const snapshot = `${vmajor}.${vminor}.${patch}`;
 


### PR DESCRIPTION
The previous shell script concatenated a bunch of values together, handling numbers as strings rather than as numbers, eventually leading to a problem where a sufficiently large patch value (ok, it was 9) and sufficiently large build number (>999) combined to create the version string `11.0.9099000000001021`, and the patch value there is greater than 2^53 - 1, which turns out to be the undocumented max as of npm v10.9.2.

This refactor into node preserves most of the existing behavior but manages numbers as numbers so that build numbers like 12, 123, 1234 generate patch values like 1090012, 1090123, 1091234 respectively, and adds some boundary checking (patch values max out at 900, build numbers at 999_999_999 or 9_999_999_999 depending on how the script is called).

Additional details, history, and gotchas are in the comments on the script itself.

Refs [FOLIO-4362](https://folio-org.atlassian.net/browse/FOLIO-4362)