### PR TITLE
FOLIO-4370 provide absolute path to folioci_npmver.js

### DIFF
--- a/github-actions-scripts/folioci_npmver.sh
+++ b/github-actions-scripts/folioci_npmver.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-./folioci_npmver.js "$@"
+$(dirname "$0")/folioci_npmver.js "$@"


### PR DESCRIPTION
Provide the absolute path to `folioci_npmver.js`, allowing this script to be called from anywhere. The previous incarnation, PR #350, invoked it simply as `./folioci_npmver.js` and thus operated relative to where the script was being called from, rather than where it is located.

Refs [FOLIO-4370](https://folio-org.atlassian.net/browse/FOLIO-4370)