### PR TITLE
Bump idna from 2.8 to 3.16 fixing CVE-2026-45409 ReDoS

### DIFF
--- a/kubernetes-utilities/ci-cleanup/module-cleanup/requirements.txt
+++ b/kubernetes-utilities/ci-cleanup/module-cleanup/requirements.txt
@@ -2,7 +2,7 @@ cachetools==3.1.1
 certifi==2023.7.22
 chardet==3.0.4
 google-auth==1.7.0
-idna==2.8
+idna==3.16
 kubernetes==10.0.1
 natsort==6.0.0
 oauthlib==3.1.0

--- a/kubernetes-utilities/md2kubeyaml/requirements.txt
+++ b/kubernetes-utilities/md2kubeyaml/requirements.txt
@@ -1,6 +1,6 @@
 certifi==2023.7.22
 chardet==3.0.4
-idna==2.8
+idna==3.16
 Jinja2==2.11.3
 MarkupSafe==1.1.1
 pkg-resources==0.0.0

--- a/vufind-indexer/requirements.txt
+++ b/vufind-indexer/requirements.txt
@@ -1,6 +1,6 @@
 certifi==2023.7.22
 chardet==3.0.4
-idna==2.8
+idna==3.16
 jmespath==0.9.4
 requests==2.31.0
 urllib3==1.26.5


### PR DESCRIPTION
Fix https://github.com/advisories/GHSA-65pc-fj4g-8rjx

The only breaking change for 3.0 is dropping support for Python 2: https://github.com/kjd/idna/blob/master/HISTORY.md#30-2021-01-01

This code uses Python 3:
* https://github.com/folio-org/folio-tools/blob/master/kubernetes-utilities/ci-cleanup/module-cleanup/Dockerfile#L1
* https://github.com/folio-org/folio-tools/blob/master/kubernetes-utilities/md2kubeyaml/Dockerfile#L1
* https://github.com/folio-org/folio-tools/blob/master/vufind-indexer/Dockerfile#L1