### PR TITLE
SECURITY-1113: module-cleanup: bump pyasn1 to 0.6.4 fixing CVEs

### DIFF
--- a/kubernetes-utilities/ci-cleanup/module-cleanup/requirements.txt
+++ b/kubernetes-utilities/ci-cleanup/module-cleanup/requirements.txt
@@ -6,7 +6,7 @@ idna==3.16
 kubernetes==10.0.1
 natsort==6.0.0
 oauthlib==3.1.0
-pyasn1==0.6.3
+pyasn1==0.6.4
 pyasn1-modules==0.4.2
 python-dateutil==2.8.1
 PyYAML==5.4


### PR DESCRIPTION
In kubernetes-utilities/ci-cleanup/module-cleanup/requirements.txt bump pyasn1 from 0.6.3 to 0.6.4 fixing multiple security vulnerabilities, see https://github.com/pyasn1/pyasn1/releases/tag/v0.6.4:

* CVE-2026-59885 (GHSA-8ppf-4f7h-5ppj): Fixed quadratic time complexity in the OBJECT IDENTIFIER and RELATIVE-OID decoders. A small crafted substrate encoding many arcs could consume excessive CPU.
* CVE-2026-59884 (GHSA-m4p7-r5rc-7g4j): Limited BER long-form tag IDs to 20 octets (140 bits). Unbounded tag IDs allowed a crafted substrate to consume excessive CPU and memory.
* CVE-2026-59886 (GHSA-hm4w-wwcw-mr6r): Fixed excessive memory and CPU consumption in `Real.__float__()` for values with large base-10 exponents.
* Pinned PyPI publish GitHub Action to an immutable commit.